### PR TITLE
Added keys for Wildwing Ripper Tornado and Ancient Black Dragon Fireball pointing to image assets

### DIFF
--- a/build/neutral_abilities.json
+++ b/build/neutral_abilities.json
@@ -17,6 +17,9 @@
 "tornado_tempest": {
 "img": "/assets/images/dota2/neutral_abilities/enraged_wildkin_tornado.png"
 },
+"enraged_wildkin_tornado": {
+"img": "/assets/images/dota2/neutral_abilities/enraged_wildkin_tornado.png"
+},
 "mud_golem_hurl_boulder": {
 "img": "/assets/images/dota2/neutral_abilities/mud_golem_hurl_boulder.png"
 },
@@ -34,7 +37,7 @@
 },
 "hill_troll_priest_heal": {
 "img": "/assets/images/dota2/neutral_abilities/hill_troll_priest_heal.png"
-}
+},
 "black_dragon_fireball": {
 "img": "/assets/images/dota2/neutral_abilities/black_dragon_fireball.png"
 }

--- a/build/neutral_abilities.json
+++ b/build/neutral_abilities.json
@@ -35,4 +35,7 @@
 "hill_troll_priest_heal": {
 "img": "/assets/images/dota2/neutral_abilities/hill_troll_priest_heal.png"
 }
+"black_dragon_fireball": {
+"img": "/assets/images/dota2/neutral_abilities/black_dragon_fireball.png"
+}
 }


### PR DESCRIPTION
Image assets in odota/ui/assets/images/dota2/neutral_abilities

Fixes odota/ui#1001