### PR TITLE
[ADD] visage_summon_familiars_stone_form to neutral_abilities.json

### DIFF
--- a/json/neutral_abilities.json
+++ b/json/neutral_abilities.json
@@ -34,5 +34,8 @@
 },
 "hill_troll_priest_heal": {
 "img": "/assets/images/dota2/neutral_abilities/hill_troll_priest_heal.png"
+},
+"visage_summon_familiars_stone_form": {
+"img": "/assets/images/dota2/neutral_abilities/visage_summon_familiars_stone_form.png"
 }
 }


### PR DESCRIPTION
This PR is for this [issue](https://github.com/odota/ui/issues/1068#issuecomment-319128778).

I have added the visage-summon-familiars-stone-form in the neutral_abilites.json as per our discussion [here](https://github.com/odota/ui/issues/1068#issuecomment-319125322).