### PR TITLE
Removed redundant h1 tags

### DIFF
--- a/build/items.json
+++ b/build/items.json
@@ -3087,7 +3087,7 @@
     "active": [
       {
         "name": "Demonic Summoning",
-        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\n<h1>Warrior:</h1>Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\n<h1>Archer:</h1>Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,7,9\nAura Radius: 1200"
+        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\nWarrior: Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\nArcher: Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,7,9\nAura Radius: 1200"
       }
     ],
     "id": 106,
@@ -3132,7 +3132,7 @@
     "active": [
       {
         "name": "Demonic Summoning",
-        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\n<h1>Warrior:</h1>Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\n<h1>Archer:</h1>Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,10,15\nAura Radius: 1200"
+        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\nWarrior: Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\nArcher: Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,10,15\nAura Radius: 1200"
       }
     ],
     "id": 193,
@@ -3176,7 +3176,7 @@
     "active": [
       {
         "name": "Demonic Summoning",
-        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\n<h1>Warrior:</h1>Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\n<h1>Archer:</h1>Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,10,15\nAura Radius: 1200"
+        "desc": "Summons a Warrior and an Archer to fight for you for 60 seconds.\n\nWarrior: Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.\nHealth: 700,800,900\nDamage: 75,100,125\nMana Break Damage: 30,40,50\nLast Will Damage: 600,700,800\n\nArcher: Has a passive movement and attack speed aura. Gains Purge at Level 3.\nHealth: 700,800,900\nDamage: 60,90,120\nAura Move Speed: 5,7,9\nAura Attack Speed: 5,10,15\nAura Radius: 1200"
       }
     ],
     "id": 194,


### PR DESCRIPTION
As you can see the screenshot below, h1 tag is not straight in description field as expected.

<img width="1235" alt="screen shot 2019-02-20 at 12 45 55" src="https://user-images.githubusercontent.com/4904494/53107198-975d4b00-3545-11e9-8076-c16565f999b6.png">
 