### PR TITLE
Updated missing dname

### DIFF
--- a/build/items.json
+++ b/build/items.json
@@ -2260,6 +2260,7 @@
   "recipe_ring_of_basilius": {
     "id": 87,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1579131323023",
+    "dname": "Ring of Basilius Recipe",
     "cost": 150,
     "notes": "",
     "attrib": [],
@@ -4315,6 +4316,7 @@
   "recipe_vanguard": {
     "id": 124,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1579131323023",
+    "dname": "Vanguard Recipe",
     "cost": 200,
     "notes": "",
     "attrib": [],
@@ -6144,6 +6146,7 @@
   "recipe_solar_crest": {
     "id": 227,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1579131323023",
+    "dname": "Solar Crest Recipe",
     "cost": 400,
     "notes": "",
     "attrib": [],


### PR DESCRIPTION
Added missing dname for Vanguard recipe, Ring of Basilius recipe and Solar Crest recipe.