### PR TITLE
fix: remaining attrib replacements

### DIFF
--- a/build/abilities.json
+++ b/build/abilities.json
@@ -93,6 +93,12 @@
         "header": "MIN BLINK RANGE:",
         "value": "200",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -150,6 +156,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "1.2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -204,6 +222,18 @@
         "key": "scepter_ministun",
         "header": "SCEPTER STUN DURATION:",
         "value": "1.3"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -240,6 +270,12 @@
           "2.8",
           "3.2"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -297,6 +333,18 @@
         "key": "scepter_range",
         "header": "SCEPTER AOE:",
         "value": "400"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -399,6 +447,18 @@
         "key": "speed_aoe",
         "header": "KILL SPEED RADIUS:",
         "value": "900"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -473,6 +533,18 @@
         "key": "castpoint_scepter",
         "header": "SCEPTER CAST POINT:",
         "value": "0.2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -523,6 +595,23 @@
           "155",
           "215"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "625",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "DURATION:",
+        "value": "6"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -562,6 +651,33 @@
         "key": "animation_rate",
         "header": "ANIMATION RATE:",
         "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "425",
+          "500",
+          "575",
+          "650"
+        ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "4",
+          "5",
+          "6",
+          "7"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -652,6 +768,18 @@
         "header": "HEALTH BONUS SHARE PERCENT:",
         "value": "50",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "cd": [
@@ -707,6 +835,18 @@
         "key": "delay_plus_castpoint_tooltip",
         "header": "DELAY PLUS CASTPOINT TOOLTIP:",
         "value": "2.9",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -821,6 +961,17 @@
         "key": "charge_restore_time_scepter",
         "header": "SCEPTER REPLENISH TIME:",
         "value": "40"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "800"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -840,7 +991,7 @@
     ],
     "dmg_type": "Physical",
     "bkbpierce": "No",
-    "desc": "Adds a freezing effect to Drow's attacks, slowing enemy movement and dealing bonus damage.  Slow lasts %abilityduration% seconds.",
+    "desc": "Adds a freezing effect to Drow's attacks, slowing enemy movement and dealing bonus damage.  Slow lasts 1.5 seconds.",
     "dmg": "0",
     "attrib": [
       {
@@ -862,6 +1013,24 @@
           "15",
           "20"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "625",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "1.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "12",
@@ -876,7 +1045,7 @@
     ],
     "dmg_type": "Physical",
     "bkbpierce": "No",
-    "desc": "Channeling. Drow releases a flurry of arrows in continuous salvos, hitting enemies for extra damage and applying longer duration Frost Arrows. Lasts up to %abilitychanneltime% seconds.",
+    "desc": "Channeling. Drow releases a flurry of arrows in continuous salvos, hitting enemies for extra damage and applying longer duration Frost Arrows. Lasts up to 1.75 seconds.",
     "attrib": [
       {
         "key": "arrow_count",
@@ -925,6 +1094,18 @@
         "header": "ARROW ANGLE:",
         "value": "50",
         "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1.75",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -955,6 +1136,29 @@
         "key": "silence_radius",
         "header": "RADIUS:",
         "value": "300"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -1013,6 +1217,17 @@
         "header": "KNOCKBACK HEIGHT:",
         "value": "0",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "900"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -1046,6 +1261,24 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "1200"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "30",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": "100",
@@ -1111,6 +1344,12 @@
         "header": "DISABLE RANGE:",
         "value": "400",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/drow_ranger_marksmanship_md.png"
@@ -1153,6 +1392,18 @@
           "1.5",
           "1.75"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.69",
+        "generated": true
       }
     ],
     "mc": [
@@ -1231,6 +1482,23 @@
         "header": "BONUS ATTACK RANGE:",
         "value": "75",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "14"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.69",
+        "generated": true
       }
     ],
     "mc": [
@@ -1259,6 +1527,16 @@
         "key": "aftershock_range",
         "header": "RADIUS:",
         "value": "300"
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": [
+          "0.6",
+          "0.9",
+          "1.2",
+          "1.5"
+        ]
       }
     ],
     "img": "/apps/dota2/images/abilities/earthshaker_aftershock_md.png"
@@ -1304,6 +1582,12 @@
           "140",
           "180"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -1377,6 +1661,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -1399,7 +1695,7 @@
       "AOE",
       "Point Target"
     ],
-    "desc": "Summons a Healing Ward which heals all nearby allied units, based on their max health.  The Healing Ward moves at 350 movement speed after being summoned.  Lasts %abilityduration% seconds.",
+    "desc": "Summons a Healing Ward which heals all nearby allied units, based on their max health.  The Healing Ward moves at 350 movement speed after being summoned.  Lasts 25 seconds.",
     "attrib": [
       {
         "key": "healing_ward_heal_amount",
@@ -1421,6 +1717,24 @@
         "key": "healing_ward_movespeed_tooltip",
         "header": "HEALING WARD MOVESPEED TOOLTIP:",
         "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -1462,6 +1776,18 @@
         "key": "omni_slash_radius",
         "header": "SLASH JUMP RADIUS:",
         "value": "425"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -1483,6 +1809,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "0.8"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -1538,6 +1876,18 @@
           "225",
           "300"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -1587,6 +1937,12 @@
         "key": "torrent_max_distance",
         "header": "TORRENT MAX DISTANCE:",
         "value": "1100",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -1646,6 +2002,18 @@
         "key": "cleave_damage",
         "header": "CLEAVE DAMAGE:",
         "value": "165%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": [
@@ -1682,6 +2050,22 @@
         "key": "fow_duration",
         "header": "FOW DURATION:",
         "value": "5.94",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "400",
+          "600",
+          "800",
+          "1000"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -1762,6 +2146,18 @@
         "key": "ghostship_absorb",
         "header": "DAMAGE DELAYED:",
         "value": "40%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -1815,6 +2211,24 @@
         "header": "DRAGON SLAVE DISTANCE:",
         "value": "1075",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1075",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "0.6875",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -1865,6 +2279,18 @@
           "160",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "625",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -1941,6 +2367,18 @@
         "header": "DAMAGE DELAY:",
         "value": "0.25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -1998,6 +2436,18 @@
         "header": "SPEED:",
         "value": "1600",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -2029,6 +2479,18 @@
         "key": "movespeed",
         "header": "MOVESPEED:",
         "value": "140",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -2090,6 +2552,24 @@
           "30%",
           "35%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "5.1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "10",
@@ -2168,6 +2648,18 @@
         "key": "splash_radius_scepter",
         "header": "SCEPTER AREA OF EFFECT:",
         "value": "325"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -2246,6 +2738,24 @@
         "header": "ARROW VISION:",
         "value": "500",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "3.11",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -2280,6 +2790,18 @@
         "key": "bonus_movement_speed",
         "header": "MOVEMENT SPEED:",
         "value": "15%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -2337,6 +2859,40 @@
         "header": "LEAP BONUS DURATION:",
         "value": "2.5",
         "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": [
+          "45",
+          "40",
+          "35",
+          "30"
+        ],
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": [
+          "45",
+          "40",
+          "35",
+          "30"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "3",
+        "generated": true
       }
     ],
     "mc": "40",
@@ -2376,6 +2932,18 @@
         "key": "secondary_starfall_damage_percent",
         "header": "SECONDARY STARFALL DAMAGE PERCENT:",
         "value": "75",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -2423,6 +2991,22 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "700",
+          "800",
+          "900",
+          "1000"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -2482,6 +3066,22 @@
         "header": "SHARED COOLDOWN:",
         "value": "3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "600",
+          "700",
+          "800",
+          "900"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -2530,6 +3130,22 @@
         "key": "shared_cooldown",
         "header": "SHARED COOLDOWN:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "600",
+          "700",
+          "800",
+          "900"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
         "generated": true
       }
     ],
@@ -2666,6 +3282,22 @@
         "key": "scepter_cast_range_bonus",
         "header": "SCEPTER BONUS CAST RANGE:",
         "value": "600"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "700",
+          "850",
+          "1000"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -2731,6 +3363,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "20"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -2785,6 +3429,12 @@
         "key": "duration",
         "header": "STACK DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -2839,6 +3489,12 @@
         "key": "duration",
         "header": "STACK DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -2893,6 +3549,12 @@
         "key": "duration",
         "header": "STACK DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -2967,6 +3629,12 @@
         "key": "presence_radius",
         "header": "RADIUS:",
         "value": "1200"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/nevermore_dark_lord_md.png"
@@ -3054,6 +3722,11 @@
         "key": "requiem_damage_pct_scepter",
         "header": "SCEPTER DAMAGE ON RETURN:",
         "value": "40%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "CAST DELAY:",
+        "value": "1.67"
       }
     ],
     "mc": [
@@ -3143,6 +3816,23 @@
         "header": "FAKE LANCE DISTANCE:",
         "value": "675",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "525",
+          "600",
+          "675",
+          "750"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -3210,6 +3900,18 @@
         "key": "illusion_extended_duration",
         "header": "ILLUSION DURATION EXTENSION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -3381,6 +4083,18 @@
         "header": "VISION DURATION:",
         "value": "3.34",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": [
@@ -3446,6 +4160,12 @@
         "key": "max_distance",
         "header": "MAX DISTANCE:",
         "value": "275"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": [
@@ -3479,6 +4199,23 @@
           "2.25",
           "3.25"
         ]
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": [
+          "0.75",
+          "1.5",
+          "2.25",
+          "3.25"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -3566,6 +4303,18 @@
           "3",
           "4.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": [
@@ -3654,6 +4403,18 @@
         "header": "VISION DURATION:",
         "value": "4",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -3710,6 +4471,12 @@
           "90",
           "120"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/pudge_rot_md.png"
@@ -3804,6 +4571,23 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "11"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "160",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "DURATION:",
+        "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -3862,6 +4646,18 @@
           "260",
           "320"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -3899,6 +4695,18 @@
           "2.75",
           "3.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -3945,6 +4753,29 @@
           "4.25",
           "5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": [
+          "2.75",
+          "3.5",
+          "4.25",
+          "5"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -4006,6 +4837,18 @@
         "key": "hits_to_destroy_tooltip",
         "header": "HITS TO DESTROY:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -4076,6 +4919,18 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "1.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -4141,6 +4996,18 @@
         "key": "vision_duration",
         "header": "VISION DURATION:",
         "value": "3.34",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -4242,6 +5109,12 @@
           "55",
           "70"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -4304,6 +5177,18 @@
           "50",
           "70"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "525",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -4407,6 +5292,12 @@
         "key": "reincarnate_time",
         "header": "REINCARNATE TIME:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -4514,6 +5405,18 @@
         "header": "SPEED:",
         "value": "1100",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -4553,6 +5456,29 @@
           "5",
           "6"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -4668,7 +5594,7 @@
     "behavior": "Unit Target",
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Creates a spirit link between Death Prophet and an enemy unit, draining 14 + 1,2.5,4,5.5% Max HP per second and steal %movement_slow%% movement speed from the enemy.",
+    "desc": "Creates a spirit link between Death Prophet and an enemy unit, draining 14 + 1,2.5,4,5.5% Max HP per second and steal 1,2.5,4,5.5% movement speed from the enemy.",
     "attrib": [
       {
         "key": "damage",
@@ -4705,6 +5631,62 @@
         "header": "SIPHON BUFFER:",
         "value": "250",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": [
+          "45",
+          "40",
+          "35",
+          "30"
+        ],
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": [
+          "45",
+          "40",
+          "35",
+          "30"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ],
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ],
+        "generated": true
       }
     ],
     "mc": "80",
@@ -4716,7 +5698,7 @@
     "behavior": "No Target",
     "dmg_type": "Physical",
     "bkbpierce": "Yes",
-    "desc": "Unleashes evil spirits to drain the life of nearby enemy units and structures. At the end of the spell's duration, Death Prophet is healed in proportion to the damage dealt. Lasts %abilityduration% seconds.",
+    "desc": "Unleashes evil spirits to drain the life of nearby enemy units and structures. At the end of the spell's duration, Death Prophet is healed in proportion to the damage dealt. Lasts 35 seconds.",
     "attrib": [
       {
         "key": "radius",
@@ -4807,6 +5789,18 @@
           "18%",
           "20%"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "35",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -4864,6 +5858,18 @@
         "key": "cast_range_bonus_scepter",
         "header": "SCEPTER BONUS CAST RANGE:",
         "value": "500"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -4964,6 +5970,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -4978,7 +5990,7 @@
   "sven_gods_strength": {
     "dname": "God's Strength",
     "behavior": "No Target",
-    "desc": "Sven channels his rogue strength, granting bonus strength and damage for %abilityduration% seconds.",
+    "desc": "Sven channels his rogue strength, granting bonus strength and damage for 25 seconds.",
     "attrib": [
       {
         "key": "gods_strength_damage",
@@ -4997,6 +6009,18 @@
           "20",
           "30"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -5012,7 +6036,7 @@
     "behavior": "No Target",
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Creates an explosively charged image of Storm Spirit that lasts %abilityduration% seconds and will detonate and deal damage if an enemy unit comes near it.",
+    "desc": "Creates an explosively charged image of Storm Spirit that lasts 12 seconds and will detonate and deal damage if an enemy unit comes near it.",
     "attrib": [
       {
         "key": "static_remnant_radius",
@@ -5040,6 +6064,18 @@
           "230",
           "285"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "12",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -5094,6 +6130,28 @@
         "key": "radius_scepter",
         "header": "SCEPTER RADIUS:",
         "value": "475"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": [
+          "1.4",
+          "1.8",
+          "2.2",
+          "2.6"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -5136,6 +6194,11 @@
           "80",
           "100"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "0.6"
       }
     ],
     "img": "/apps/dota2/images/abilities/storm_spirit_overload_md.png"
@@ -5206,6 +6269,12 @@
         "header": "SCEPTER REMNANT INTERVAL:",
         "value": "300",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "30",
@@ -5270,6 +6339,22 @@
         "header": "BURROW SPEED SCEPTER:",
         "value": "3000",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "400",
+          "500",
+          "600",
+          "700"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -5333,6 +6418,29 @@
         "key": "fade_delay",
         "header": "FADE DELAY:",
         "value": "0.7",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "20",
+          "25",
+          "30",
+          "35"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -5423,7 +6531,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "CHANNELED - After channeling for %abilitychanneltime% seconds, Sand King sends a disturbance into the earth, causing it to shudder violently. All enemies caught within range will take damage and become slowed. Each subsequent pulse increases the radius of damage dealt.",
+    "desc": "CHANNELED - After channeling for 2 seconds, Sand King sends a disturbance into the earth, causing it to shudder violently. All enemies caught within range will take damage and become slowed. Each subsequent pulse increases the radius of damage dealt.",
     "attrib": [
       {
         "key": "epicenter_radius",
@@ -5473,6 +6581,23 @@
         "key": "epicenter_slow_as",
         "header": "ATTACK SLOW:",
         "value": "-30"
+      },
+      {
+        "key": "abilityduration",
+        "header": "SLOW DURATION:",
+        "value": "3"
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -5545,6 +6670,18 @@
           "225",
           "300"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "120",
@@ -5603,6 +6740,22 @@
       {
         "key": "AbilityCharges",
         "header": "ABILITYCHARGES:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "850",
+          "1000",
+          "1150",
+          "1300"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
         "value": "0",
         "generated": true
       }
@@ -5741,6 +6894,18 @@
         "header": "SPEED REDUCTION:",
         "value": "30",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "165",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -5795,6 +6960,18 @@
         "key": "splash_pct",
         "header": "SPLASH DAMAGE:",
         "value": "150%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/tiny_toss_tree_md.png"
@@ -5849,6 +7026,23 @@
         "key": "abilitychanneltime",
         "header": "MAX CHANNEL TIME:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1300",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "MAX CHANNEL TIME:",
+        "value": "2.4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -5928,6 +7122,18 @@
         "header": "JUMP DELAY:",
         "value": "0.25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -5976,6 +7182,22 @@
         "key": "spread_aoe",
         "header": "SPREAD AOE:",
         "value": "325",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "700",
+          "750",
+          "800",
+          "850"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -6030,6 +7252,18 @@
         "key": "cloud_bounty_tooltip",
         "header": "CLOUD BOUNTY TOOLTIP:",
         "value": "100",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -6088,6 +7322,12 @@
           "350",
           "450"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -6157,6 +7397,18 @@
           "65%",
           "85%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -6237,6 +7489,18 @@
         "key": "puddle_radius",
         "header": "SCEPTER PUDDLE AOE:",
         "value": "600"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -6303,6 +7567,22 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "18"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "700",
+          "800",
+          "900"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -6367,6 +7647,23 @@
         "key": "cast_range_scepter",
         "header": "SCEPTER RANGE:",
         "value": "2200"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DEBUFF DURATION:",
+        "value": "4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6447,6 +7744,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "375"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "375",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -6494,6 +7803,18 @@
           "2.6",
           "2.8"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6536,6 +7857,18 @@
           "270",
           "360"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6599,6 +7932,12 @@
         "key": "illusion_damage_in_pct",
         "header": "ILLUSION DAMAGE TAKEN:",
         "value": "150%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/vengefulspirit_command_aura_md.png"
@@ -6648,6 +7987,23 @@
         "key": "vision_duration",
         "header": "VISION DURATION:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1400",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DEBUFF DURATION:",
+        "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6679,6 +8035,53 @@
         "key": "scepter_duration",
         "header": "SCEPTER FEAR DURATION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "700",
+          "850",
+          "1000"
+        ]
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": [
+          "90",
+          "80",
+          "70"
+        ],
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": [
+          "90",
+          "80",
+          "70"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "2",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "2",
+        "generated": true
       }
     ],
     "mc": [
@@ -6744,6 +8147,18 @@
           "210",
           "260"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6802,6 +8217,18 @@
         "header": "TICK INTERVAL:",
         "value": "0.7",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -6837,6 +8264,12 @@
         "key": "self_factor",
         "header": "SELF BONUS FACTOR:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/crystal_maiden_brilliance_aura_md.png"
@@ -6849,7 +8282,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "CHANNELED - Surrounds Crystal Maiden with random icy explosions that slow enemies and deal massive damage. Grants bonus armor while channeling. Lasts %abilitychanneltime% seconds.",
+    "desc": "CHANNELED - Surrounds Crystal Maiden with random icy explosions that slow enemies and deal massive damage. Grants bonus armor while channeling. Lasts 10 seconds.",
     "attrib": [
       {
         "key": "radius",
@@ -6913,6 +8346,24 @@
         "key": "scepter_delay",
         "header": "SCEPTER FROSTBITE DELAY:",
         "value": "2"
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -6973,6 +8424,18 @@
         "header": "SHACKLE ANGLE:",
         "value": "23",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
+        "generated": true
       }
     ],
     "mc": [
@@ -6997,7 +8460,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Windranger charges her bow for up to %abilitychanneltime% second for a single powerful shot, which deals more damage the longer it is charged. The arrow damages enemies along its path. For each enemy that Powershot hits, its damage is reduced by 20%.",
+    "desc": "Windranger charges her bow for up to 1 second for a single powerful shot, which deals more damage the longer it is charged. The arrow damages enemies along its path. For each enemy that Powershot hits, its damage is reduced by 20%.",
     "attrib": [
       {
         "key": "powershot_damage",
@@ -7048,6 +8511,24 @@
         "key": "vision_duration",
         "header": "VISION DURATION:",
         "value": "3.34",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2600",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -7128,6 +8609,23 @@
         "key": "scepter_bonus_movement",
         "header": "SCEPTER MOVE SPEED BONUS:",
         "value": "45%"
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -7164,6 +8662,23 @@
         "header": "FOCUSFIRE FIRE ON THE MOVE:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "20"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -7186,7 +8701,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Blasts the target enemy unit with damaging frost, dealing area damage and slowing movement and attack rates for %abilityduration% seconds.  The primary target receives both base and area damage.",
+    "desc": "Blasts the target enemy unit with damaging frost, dealing area damage and slowing movement and attack rates for 4 seconds.  The primary target receives both base and area damage.",
     "dmg": [
       "50",
       "100",
@@ -7218,6 +8733,24 @@
           "125",
           "150"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -7332,6 +8865,17 @@
         "key": "aoe_scepter",
         "header": "SCEPTER AOE:",
         "value": "400"
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": [
+          "1.4",
+          "1.7",
+          "2",
+          "2.3"
+        ],
+        "generated": true
       }
     ],
     "mc": [
@@ -7375,6 +8919,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "1"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/lich_frost_aura_md.png"
@@ -7385,7 +8935,7 @@
       "Unit Target",
       "Autocast"
     ],
-    "desc": "Creates a shield around the target friendly unit or building, which adds armor and slows attacking units. Lasts %abilityduration% seconds.",
+    "desc": "Creates a shield around the target friendly unit or building, which adds armor and slows attacking units. Lasts 40 seconds.",
     "attrib": [
       {
         "key": "armor_bonus",
@@ -7421,6 +8971,24 @@
           "-24",
           "-32"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "40",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -7484,6 +9052,18 @@
         "key": "duration",
         "header": "BUFF DURATION:",
         "value": "6"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -7561,6 +9141,18 @@
           "20",
           "25"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -7641,6 +9233,18 @@
           "6",
           "8"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -7753,6 +9357,23 @@
         "header": "TICKS:",
         "value": "3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "575",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "12"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -7777,7 +9398,7 @@
     ],
     "dmg_type": "Physical",
     "bkbpierce": "Yes",
-    "desc": "CHANNELED - Summons a deadly ward to attack enemy heroes within it's attack range. Lasts a maximum of %abilitychanneltime% seconds.",
+    "desc": "CHANNELED - Summons a deadly ward to attack enemy heroes within it's attack range. Lasts a maximum of 8 seconds.",
     "attrib": [
       {
         "key": "damage",
@@ -7797,6 +9418,24 @@
         "key": "bounce_radius",
         "header": "BOUNCE RADIUS:",
         "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "8",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
         "generated": true
       }
     ],
@@ -7837,6 +9476,24 @@
           "45%",
           "55%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "6",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -7869,6 +9526,56 @@
           "75",
           "100"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "600",
+          "700",
+          "800",
+          "900"
+        ]
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": [
+          "25",
+          "20",
+          "15",
+          "10"
+        ],
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": [
+          "25",
+          "20",
+          "15",
+          "10"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "2",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -7981,6 +9688,23 @@
         "key": "scepter_cast_range",
         "header": "SCEPTER CAST RANGE:",
         "value": "1000"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "DURATION:",
+        "value": "2"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -8035,6 +9759,18 @@
         "key": "tooltip_stuns",
         "header": "INSTANCES:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -8091,6 +9827,23 @@
           "38",
           "47"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "35"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -8136,6 +9889,18 @@
           "11",
           "12"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": [
@@ -8233,6 +9998,24 @@
         "header": "ANIMATION RATE:",
         "value": "0.2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "275",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -8288,6 +10071,17 @@
         "key": "scepter_bounce_range",
         "header": "SCEPTER REFRACT RADIUS:",
         "value": "400"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "650"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -8341,6 +10135,12 @@
         "key": "targets_scepter",
         "header": "SCEPTER TARGETS:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -8418,6 +10218,18 @@
           "32",
           "40"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.53",
+        "generated": true
       }
     ],
     "mc": [
@@ -8436,7 +10248,23 @@
       "Channeled"
     ],
     "desc": "CHANNELED - Resets the cooldown on most of Tinker's items and abilities.",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "abilitychanneltime",
+        "header": "TIME TO REARM:",
+        "value": [
+          "3",
+          "1.5",
+          "0.75"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.53",
+        "generated": true
+      }
+    ],
     "mc": [
       "100",
       "200",
@@ -8453,7 +10281,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Consumes a charge to launch a ball of shrapnel that showers the target area in explosive pellets. Enemies are subject to damage and slowed movement. Reveals the targeted area. Shrapnel charges restore every %abilitychargerestoretime% seconds.",
+    "desc": "Consumes a charge to launch a ball of shrapnel that showers the target area in explosive pellets. Enemies are subject to damage and slowed movement. Reveals the targeted area. Shrapnel charges restore every 40 seconds.",
     "attrib": [
       {
         "key": "slow_movement_speed",
@@ -8501,6 +10329,42 @@
         "key": "AbilityCharges",
         "header": "ABILITYCHARGES:",
         "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1800",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": "40",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "40",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "3",
         "generated": true
       }
     ],
@@ -8569,6 +10433,18 @@
         "header": "ACTIVE ATTACK RANGE MULTIPLIER:",
         "value": "2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "30",
@@ -8615,6 +10491,16 @@
         "key": "scepter_cast_point",
         "header": "SCEPTER AIM DURATION:",
         "value": "0.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "3000"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "AIM DURATION:",
+        "value": "2"
       }
     ],
     "mc": [
@@ -8661,6 +10547,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -8789,6 +10687,12 @@
         "key": "cooldown_scepter",
         "header": "SCEPTER COOLDOWN:",
         "value": "10"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -8838,6 +10742,18 @@
           "25",
           "35"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": [
@@ -8880,6 +10796,18 @@
         "header": "SEARCH AOE:",
         "value": "700",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "140",
@@ -8914,6 +10842,22 @@
         "header": "TICK INTERVAL:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "450",
+          "550",
+          "650",
+          "750"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -8933,7 +10877,7 @@
       "AOE"
     ],
     "bkbpierce": "No",
-    "desc": "CHANNELED - A powerful slowing current that grows stronger as it's channelled. Lasts up to %abilitychanneltime% seconds.  Enemies are slowed for 3 seconds after leaving the area or the spell ends.",
+    "desc": "CHANNELED - A powerful slowing current that grows stronger as it's channelled. Lasts up to 16 seconds.  Enemies are slowed for 3 seconds after leaving the area or the spell ends.",
     "dmg": "0",
     "attrib": [
       {
@@ -8961,6 +10905,24 @@
         "key": "max_slow",
         "header": "MAX SLOW:",
         "value": "84%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "16",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -9073,6 +11035,18 @@
         "key": "bounty_reduction_scepter",
         "header": "SCEPTER BOUNTY REDUCTION:",
         "value": "50%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -9186,6 +11160,18 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -9299,6 +11285,12 @@
         "key": "boar_poison_duration_tooltip",
         "header": "BOAR POISON DURATION:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -9352,6 +11344,18 @@
           "800",
           "900"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "30",
@@ -9588,6 +11592,18 @@
         "header": "MOVEMENT SPEED DURATION:",
         "value": "3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -9607,7 +11623,7 @@
     "behavior": "Unit Target",
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Hurls a poisoned dagger which deals large initial damage, and then deals damage over time. The poisoned unit has its movement speed slowed for %abilityduration% seconds.  An instance of damage is dealt every 3 seconds.",
+    "desc": "Hurls a poisoned dagger which deals large initial damage, and then deals damage over time. The poisoned unit has its movement speed slowed for 15 seconds.  An instance of damage is dealt every 3 seconds.",
     "attrib": [
       {
         "key": "strike_damage",
@@ -9650,6 +11666,27 @@
         "header": "DAMAGE INTERVAL:",
         "value": "3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "450",
+          "500",
+          "550",
+          "600"
+        ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "15"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "110",
@@ -9675,6 +11712,18 @@
         "key": "min_blink_range",
         "header": "MIN BLINK RANGE:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.33",
         "generated": true
       }
     ],
@@ -9709,6 +11758,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -9787,6 +11848,18 @@
         "header": "KNOCKBACK DURATION:",
         "value": "1.4",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.452",
+        "generated": true
       }
     ],
     "mc": [
@@ -9853,6 +11926,18 @@
         "key": "speed",
         "header": "SPEED:",
         "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -9968,6 +12053,18 @@
           "80"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "20",
@@ -10034,6 +12131,12 @@
         "key": "speed",
         "header": "TRAVEL SPEED",
         "value": "500"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -10076,6 +12179,18 @@
         "key": "radius_scepter",
         "header": "SCEPTER TIMELOCK RADIUS:",
         "value": "250"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "40",
@@ -10175,6 +12290,12 @@
         "key": "cooldown_percentage",
         "header": "COOLDOWN PROGRESSION SLOW:",
         "value": "75%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -10219,6 +12340,18 @@
         "key": "bonus_attack_speed",
         "header": "BONUS ATTACK SPEED:",
         "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
         "generated": true
       }
     ],
@@ -10265,6 +12398,18 @@
           "250",
           "325"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -10317,6 +12462,28 @@
         "key": "abilityduration",
         "header": "DURATION:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "400",
+          "500",
+          "600",
+          "700"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "3.5"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -10369,6 +12536,28 @@
         "key": "attacks_to_destroy_tooltip",
         "header": "ATTACKS TO DESTROY:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "WARD DURATION:",
+        "value": [
+          "18",
+          "22",
+          "26",
+          "30"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -10419,6 +12608,22 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "700"
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "MAX DURATION:",
+        "value": "10"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -10482,6 +12687,22 @@
           "55%",
           "70%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "525",
+          "750",
+          "975",
+          "1200"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "30",
@@ -10508,6 +12729,17 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1000"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -10558,6 +12790,18 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "12"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -10632,6 +12876,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "17"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -10643,7 +12893,7 @@
     "behavior": "No Target",
     "dmg_type": "Physical",
     "bkbpierce": "Yes",
-    "desc": "Templar Assassin conceals herself, becoming invisible as long as she remains still.  If Meld's invisibility is broken by attacking an enemy, Lanaya will deal bonus damage to the enemy and reduce their armor for %abilityduration% seconds.",
+    "desc": "Templar Assassin conceals herself, becoming invisible as long as she remains still.  If Meld's invisibility is broken by attacking an enemy, Lanaya will deal bonus damage to the enemy and reduce their armor for 12 seconds.",
     "attrib": [
       {
         "key": "bonus_damage",
@@ -10664,6 +12914,17 @@
           "-6",
           "-8"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ARMOR REDUCTION DURATION:",
+        "value": "12"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -10761,6 +13022,18 @@
         "header": "TRAP MAX CHARGE DURATION:",
         "value": "4",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "15",
@@ -10820,6 +13093,12 @@
         "key": "trap_max_charge_duration",
         "header": "TRAP MAX CHARGE DURATION:",
         "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -10886,6 +13165,18 @@
         "key": "tooltip_cooldown",
         "header": "COOLDOWN:",
         "value": "30"
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -10940,6 +13231,12 @@
         "key": "trap_max_charge_duration",
         "header": "TRAP MAX CHARGE DURATION:",
         "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -11009,6 +13306,23 @@
           "145"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "600",
+          "640",
+          "680",
+          "720"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -11064,6 +13378,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -11197,6 +13523,18 @@
         "header": "CHARGE RESTORE TIME:",
         "value": "30",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -11232,6 +13570,18 @@
           "225",
           "300"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -11429,6 +13779,27 @@
         "header": "NIGHT DURATION:",
         "value": "10",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ECLIPSE DURATION:",
+        "value": [
+          "2.4",
+          "4.2",
+          "6"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.6",
+        "generated": true
       }
     ],
     "mc": [
@@ -11489,6 +13860,18 @@
         "key": "duration",
         "header": "REDUCTION DURATION:",
         "value": "11"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -11538,6 +13921,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "1600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -11800,6 +14195,22 @@
           "6",
           "7"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "500",
+          "600",
+          "700",
+          "800"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -11825,6 +14236,22 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "550",
+          "700",
+          "850",
+          "1000"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -11883,6 +14310,18 @@
           "120",
           "140"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -11932,6 +14371,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "24"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -11982,6 +14433,12 @@
         "key": "scepter_count",
         "header": "SCEPTER COUNT:",
         "value": "8",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
         "generated": true
       }
     ],
@@ -12139,6 +14596,12 @@
         "header": "EXTRA PULL BUFFER:",
         "value": "-10",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -12187,6 +14650,18 @@
           "160",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -12255,6 +14730,21 @@
         "header": "COOLDOWN SCEPTER:",
         "value": "12",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "2000",
+          "2500",
+          "3000"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -12300,6 +14790,24 @@
         "key": "duration",
         "header": "STUN DURATION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.7",
+        "generated": true
       }
     ],
     "mc": [
@@ -12316,7 +14824,7 @@
     "behavior": "No Target",
     "dmg_type": "Physical",
     "bkbpierce": "Yes",
-    "desc": "Saturates the area around Leshrac with magical explosions that deal physical damage to enemy units and structures.  The fewer units available to attack, the more damage those units will take.  Deals 40% more damage to towers.  Lasts %abilityduration% seconds.",
+    "desc": "Saturates the area around Leshrac with magical explosions that deal physical damage to enemy units and structures.  The fewer units available to attack, the more damage those units will take.  Deals 40% more damage to towers.  Lasts 10 seconds.",
     "dmg": [
       "8",
       "20",
@@ -12338,6 +14846,18 @@
         "key": "tower_bonus",
         "header": "TOWER BONUS:",
         "value": "40",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
         "generated": true
       }
     ],
@@ -12408,6 +14928,18 @@
         "key": "radius_scepter",
         "header": "SCEPTER RADIUS:",
         "value": "750"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -12451,6 +14983,12 @@
           "150",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "70",
@@ -12480,6 +15018,22 @@
           "5",
           "6"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "625",
+          "700",
+          "775",
+          "850"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -12503,7 +15057,19 @@
       null
     ],
     "desc": "Teleports to any point on the map.",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "CAST TIME:",
+        "value": "3"
+      }
+    ],
     "mc": "50",
     "cd": [
       "50",
@@ -12595,6 +15161,18 @@
           "108"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -12685,6 +15263,18 @@
           "108"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -12717,6 +15307,29 @@
           "5",
           "6"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "3",
+          "4",
+          "5",
+          "6"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -12787,6 +15400,28 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "200",
+          "300",
+          "400",
+          "500"
+        ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "8",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "140",
@@ -12860,6 +15495,18 @@
           "4%",
           "5%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -12894,6 +15541,18 @@
         "header": "ORDER LOCK DURATION:",
         "value": "2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -12920,6 +15579,12 @@
         "key": "radius_tooltip",
         "header": "ERUPT RADIUS:",
         "value": "700"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/life_stealer_assimilate_eject_md.png"
@@ -13044,6 +15709,22 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "12"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "450",
+          "500",
+          "550",
+          "600"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -13092,6 +15773,18 @@
         "header": "TICK INTERVAL:",
         "value": "0.1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -13122,6 +15815,18 @@
         "key": "speed_boost",
         "header": "SPEED BONUS:",
         "value": "250"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -13208,6 +15913,17 @@
         "key": "scepter_length_multiplier",
         "header": "SCEPTER LENGTH MULTIPLIER:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1300"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -13241,6 +15957,12 @@
           "210",
           "260"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -13277,6 +15999,18 @@
           "45",
           "55"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "625",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -13358,6 +16092,12 @@
           "65%",
           "75%"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -13411,6 +16151,18 @@
         "key": "spawn_interval",
         "header": "SPAWN INTERVAL:",
         "value": "0.7"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -13479,6 +16231,18 @@
           "4",
           "5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -13508,6 +16272,18 @@
         "key": "radius",
         "header": "DAMAGE RADIUS:",
         "value": "260"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -13558,6 +16334,18 @@
           "16",
           "20"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -13603,6 +16391,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "7"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -13652,6 +16452,12 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "300"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "275",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/omniknight_degen_aura_md.png"
@@ -13688,6 +16494,12 @@
         "key": "scepter_regen",
         "header": "SCEPTER HP REGEN:",
         "value": "40"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -13799,6 +16611,28 @@
         "key": "slow_movement_speed",
         "header": "HERO MOVE SLOW:",
         "value": "-55%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "HERO SLOW DURATION:",
+        "value": [
+          "3.75",
+          "4.5",
+          "5.25",
+          "6"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -13813,7 +16647,7 @@
   "enchantress_natures_attendants": {
     "dname": "Nature's Attendants",
     "behavior": "No Target",
-    "desc": "A cloud of wisps heals Enchantress and any friendly units nearby. Lasts %abilityduration% seconds.",
+    "desc": "A cloud of wisps heals Enchantress and any friendly units nearby. Lasts 11 seconds.",
     "attrib": [
       {
         "key": "heal_interval",
@@ -13845,6 +16679,18 @@
           "8",
           "10"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "11",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -13882,6 +16728,24 @@
         "header": "DISTANCE CAP:",
         "value": "1750",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "575",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "1.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "65",
@@ -13896,7 +16760,7 @@
   "huskar_inner_vitality": {
     "dname": "Inner Vitality",
     "behavior": "Unit Target",
-    "desc": "Unlocks the regenerative power of a friendly unit, with healing based upon its primary attribute. If the target is below 35%, it will heal faster.  Lasts %abilityduration% seconds.",
+    "desc": "Unlocks the regenerative power of a friendly unit, with healing based upon its primary attribute. If the target is below 35%, it will heal faster.  Lasts 16,16,16,16 seconds.",
     "attrib": [
       {
         "key": "heal",
@@ -13950,6 +16814,24 @@
           "38%",
           "46%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "16",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -14008,6 +16890,18 @@
         "header": "KNOCKBACK DURATION:",
         "value": "0.6",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -14033,7 +16927,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Huskar sets his spears aflame, dealing damage over time with his regular attack.  Multiple attacks will stack additional damage.  Each attack drains some of Huskar's health.  Lasts %abilityduration% seconds.",
+    "desc": "Huskar sets his spears aflame, dealing damage over time with his regular attack.  Multiple attacks will stack additional damage.  Each attack drains some of Huskar's health.  Lasts 8 seconds.",
     "attrib": [
       {
         "key": "health_cost",
@@ -14049,6 +16943,24 @@
           "15",
           "20"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "450",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "8",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -14157,6 +17069,28 @@
         "key": "taunt_duration",
         "header": "TAUNT DURATION:",
         "value": "2.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "3",
+          "4",
+          "5"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -14210,6 +17144,18 @@
         "key": "scepter_ministun",
         "header": "SCEPTER STUN:",
         "value": "0.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "525",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -14251,6 +17197,18 @@
         "key": "radius",
         "header": "AURA RADIUS:",
         "value": "375"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "375",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -14308,6 +17266,12 @@
           "100",
           "150"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -14364,6 +17328,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -14430,7 +17406,7 @@
       "Point Target",
       "AOE"
     ],
-    "desc": "Spins a large web that grants Broodmother a passive movement speed increase, gives free movement, and boosts regeneration while in its vicinity. Spin Web charges restore every %charge_restore_time% seconds. Spin Web can be cast from anywhere as long as the new web touches an existing web. Webs never expire, and can be manually destroyed. When the maximum limit of webs is exceeded, the oldest web disappears.",
+    "desc": "Spins a large web that grants Broodmother a passive movement speed increase, gives free movement, and boosts regeneration while in its vicinity. Spin Web charges restore every 45 seconds. Spin Web can be cast from anywhere as long as the new web touches an existing web. Webs never expire, and can be manually destroyed. When the maximum limit of webs is exceeded, the oldest web disappears.",
     "attrib": [
       {
         "key": "radius",
@@ -14496,6 +17472,50 @@
           "10",
           "14",
           "18"
+        ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": "45",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "45"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": [
+          "2",
+          "4",
+          "6",
+          "8"
+        ],
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX WEB CHARGES:",
+        "value": [
+          "2",
+          "4",
+          "6",
+          "8"
         ]
       }
     ],
@@ -14564,6 +17584,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "14"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -14612,6 +17638,18 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "6"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -14702,6 +17740,12 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "65",
@@ -14770,6 +17814,17 @@
           "20%",
           "24%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1000"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "65",
@@ -14840,6 +17895,18 @@
         "header": "SPAWN RADIUS:",
         "value": "300",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "110",
@@ -14896,6 +17963,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "70",
@@ -14957,6 +18030,18 @@
         "key": "cast_range_tooltip_scepter",
         "header": "SCEPTER ALLY CAST RANGE:",
         "value": "1000"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -15045,6 +18130,23 @@
         "header": "SPEED FIRE:",
         "value": "1050",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "5"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": [
@@ -15088,6 +18190,18 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": "50"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.65",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -15134,6 +18248,23 @@
           "20",
           "24"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "5"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": [
@@ -15206,6 +18337,17 @@
         "header": "LINGER DURATION:",
         "value": "2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "FLAME LENGTH:",
+        "value": "1400"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.55",
+        "generated": true
       }
     ],
     "mc": [
@@ -15264,6 +18406,23 @@
         "key": "max_stacks",
         "header": "MAX STACKS:",
         "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "550",
+          "600",
+          "650",
+          "700"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -15356,6 +18515,18 @@
         "header": "KNOCKBACK DURATION:",
         "value": "0.35",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -15433,6 +18604,12 @@
           "600",
           "800"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -15491,6 +18668,18 @@
           "40",
           "60"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "100",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "225",
@@ -15542,6 +18731,18 @@
           "90",
           "120"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -15604,6 +18805,18 @@
           "150",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -15650,6 +18863,18 @@
         "key": "teleport_delay",
         "header": "TELEPORT DELAY:",
         "value": "6"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "130",
@@ -15674,6 +18899,18 @@
           "4",
           "3"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -15735,6 +18972,18 @@
           "24",
           "32"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -15768,6 +19017,12 @@
           "2",
           "3"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -15857,6 +19112,18 @@
         "key": "dagger_grace_period",
         "header": "DAGGER GRACE PERIOD:",
         "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -15989,6 +19256,12 @@
         "header": "ATTACK DELAY:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -16063,6 +19336,12 @@
         "key": "tooltip_cooldown",
         "header": "COOLDOWN:",
         "value": "35"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "180",
@@ -16117,6 +19396,18 @@
           "6",
           "6"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -16164,6 +19455,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "16"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -16230,6 +19533,18 @@
         "key": "burn_duration_scepter",
         "header": "BURN DURATION SCEPTER:",
         "value": "6"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "175",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "40",
@@ -16266,6 +19581,18 @@
         "key": "deniable_pct",
         "header": "DENIABLE PCT:",
         "value": "25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
         "generated": true
       }
     ],
@@ -16334,6 +19661,28 @@
         "header": "ABILITYCHARGES:",
         "value": "0",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "700",
+          "800",
+          "900",
+          "1000"
+        ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -16400,6 +19749,24 @@
         "key": "vortex_duration",
         "header": "DURATION:",
         "value": "16"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "16",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": [
@@ -16543,6 +19910,18 @@
         "header": "TARGET SIGHT RADIUS:",
         "value": "500",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "175",
@@ -16616,6 +19995,18 @@
         "key": "scepter_speed",
         "header": "SCEPTER SPEED BONUS:",
         "value": "100"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.47",
+        "generated": true
       }
     ],
     "mc": [
@@ -16824,6 +20215,17 @@
         "header": "FADE TIME:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "700"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -16846,7 +20248,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Ursa leaps forward 250 units and slams the earth, causing a powerful shock to damage and slow all enemy units in a nearby area for %abilityduration% seconds.",
+    "desc": "Ursa leaps forward 250 units and slams the earth, causing a powerful shock to damage and slow all enemy units in a nearby area for 4 seconds.",
     "dmg": [
       "75",
       "125",
@@ -16886,6 +20288,24 @@
         "header": "HOP HEIGHT:",
         "value": "83",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "85",
@@ -16916,6 +20336,23 @@
         "key": "attack_speed_bonus_pct",
         "header": "BONUS ATTACK SPEED:",
         "value": "400"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "20"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -17003,6 +20440,12 @@
           "24",
           "18"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -17021,7 +20464,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Launches a salvo of rockets at nearby enemy units in a radius around the Gyrocopter.  Lasts %abilityduration% seconds.",
+    "desc": "Launches a salvo of rockets at nearby enemy units in a radius around the Gyrocopter.  Lasts 3 seconds.",
     "attrib": [
       {
         "key": "radius",
@@ -17042,6 +20485,24 @@
           "17",
           "22"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -17139,6 +20600,18 @@
         "header": "ABILITYCHARGES:",
         "value": "0",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1050",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -17163,7 +20636,7 @@
     ],
     "dmg_type": "Physical",
     "bkbpierce": "Yes",
-    "desc": "Gyrocopter's attacks hit all enemy units in an area around it for a limited number of attacks.  Only the main target of attacks will receive attack bonuses such as Critical Strike.  Lasts %abilityduration% seconds or until the attacks are used.",
+    "desc": "Gyrocopter's attacks hit all enemy units in an area around it for a limited number of attacks.  Only the main target of attacks will receive attack bonuses such as Critical Strike.  Lasts 10 seconds or until the attacks are used.",
     "attrib": [
       {
         "key": "radius",
@@ -17195,6 +20668,18 @@
         "key": "scepter_radius",
         "header": "SIDE GUNNER ATTACK RADIUS:",
         "value": "700"
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -17277,6 +20762,18 @@
         "header": "MISSILE DELAY TOOLTIP:",
         "value": "2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -17332,6 +20829,18 @@
         "key": "tick_rate",
         "header": "TICK RATE:",
         "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -17402,6 +20911,18 @@
         "key": "radius",
         "header": "EXPLOSION RADIUS:",
         "value": "200"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "775",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "120",
@@ -17485,6 +21006,18 @@
         "key": "brew_explosion",
         "header": "BREW EXPLOSION:",
         "value": "7",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "775",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -17603,6 +21136,12 @@
         "key": "scepter_spell_amp",
         "header": "SCEPTER SPELL AMP:",
         "value": "6%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -17825,6 +21364,18 @@
         "header": "DAMAGE TRIGGER:",
         "value": "10",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -17886,6 +21437,12 @@
         "key": "aura_fade_time",
         "header": "AURA FADE TIME:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
         "generated": true
       }
     ],
@@ -17980,6 +21537,18 @@
           "315",
           "360"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -18027,6 +21596,18 @@
         "key": "damage_per_mana_pct",
         "header": "BURN DAMAGE:",
         "value": "60%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "950",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -18075,6 +21656,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "9"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -18172,6 +21765,18 @@
           "32.5",
           "36"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -18243,6 +21848,18 @@
         "key": "cataclysm_max_range",
         "header": "CATACLYSM MAX RANGE:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
         "generated": true
       }
     ],
@@ -18344,6 +21961,12 @@
           "80",
           "90"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -18460,6 +22083,12 @@
         "header": "WALL ELEMENT RADIUS:",
         "value": "105",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "175",
@@ -18548,6 +22177,18 @@
           "5.75",
           "6.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "300",
@@ -18601,6 +22242,18 @@
         "header": "DAMAGE TRIGGER:",
         "value": "10",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -18651,6 +22304,12 @@
         "key": "aura_fade_time",
         "header": "AURA FADE TIME:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
         "generated": true
       }
     ],
@@ -18728,6 +22387,18 @@
           "240",
           "315"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -18768,6 +22439,18 @@
         "key": "damage_per_mana_pct",
         "header": "BURN DAMAGE:",
         "value": "60%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "950",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -18803,6 +22486,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "9"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "60",
@@ -18867,6 +22562,18 @@
         "key": "cataclysm_max_range",
         "header": "CATACLYSM MAX RANGE:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
         "generated": true
       }
     ],
@@ -18939,6 +22646,12 @@
           "62",
           "80"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -19019,6 +22732,18 @@
           "26.5",
           "32.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -19089,6 +22814,12 @@
         "key": "wall_element_radius",
         "header": "WALL ELEMENT RADIUS:",
         "value": "105",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
         "generated": true
       }
     ],
@@ -19161,6 +22892,18 @@
           "4.5",
           "5.75"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "300",
@@ -19211,6 +22954,18 @@
           "-15%",
           "-18%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -19267,6 +23022,18 @@
           "30",
           "40"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "15",
@@ -19319,6 +23086,18 @@
         "key": "scepter_radius",
         "header": "SCEPTER RADIUS:",
         "value": "600"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "115",
@@ -19340,6 +23119,21 @@
         "key": "abilityduration",
         "header": "DURATION:",
         "value": "0"
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": [
+          "4.5",
+          "5.25",
+          "6"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -19375,6 +23169,12 @@
         "key": "counter_duration",
         "header": "COUNTER DURATION:",
         "value": "35",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "450",
         "generated": true
       }
     ],
@@ -19437,6 +23237,28 @@
         "key": "counter_duration",
         "header": "COUNTER DURATION:",
         "value": "35",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "225",
+          "300",
+          "375",
+          "450"
+        ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "4",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
         "generated": true
       }
     ],
@@ -19617,6 +23439,18 @@
         "key": "counter_duration",
         "header": "SANITY ECLIPSE CHARGE DURATION:",
         "value": "35"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -19694,6 +23528,12 @@
         "key": "tooltip_wolf_count",
         "header": "WOLF COUNT:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "145",
@@ -19707,7 +23547,7 @@
       "Hidden",
       null
     ],
-    "desc": "Lycan bites an ally, granting them Shapeshift properties. Lycan and the bitten target gain 30% Lifesteal and share %lifesteal%% Lifesteal with each other as long as they are within 1200 range of each other.",
+    "desc": "Lycan bites an ally, granting them Shapeshift properties. Lycan and the bitten target gain 30% Lifesteal and share 30% Lifesteal with each other as long as they are within 1200 range of each other.",
     "attrib": [
       {
         "key": "lifesteal_percent",
@@ -19719,6 +23559,18 @@
         "key": "lifesteal_range",
         "header": "LIFESTEAL RANGE:",
         "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -19766,6 +23618,12 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -19980,6 +23838,12 @@
           "380",
           "400"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -20083,6 +23947,12 @@
         "header": "ONLY AFFECTS PLAYER UNITS:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -20127,6 +23997,12 @@
         "key": "only_affects_player_units",
         "header": "ONLY AFFECTS PLAYER UNITS:",
         "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -20176,6 +24052,12 @@
         "key": "transformation_time",
         "header": "TRANSFORM TIME:",
         "value": "1.933"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -20195,6 +24077,12 @@
         "key": "transformation_time",
         "header": "TRANSFORM TIME:",
         "value": "1.933"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -20239,6 +24127,12 @@
         "key": "range",
         "header": "RADIUS:",
         "value": "1000"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -20257,6 +24151,18 @@
         "key": "channel_tooltip",
         "header": "CHANNEL TOOLTIP:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -20324,6 +24230,18 @@
         "key": "attack_amp",
         "header": "ATTACK AMPLIFICATION:",
         "value": "25%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "450",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -20431,6 +24349,12 @@
         "key": "duration_creeps",
         "header": "CREEP DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -20467,6 +24391,18 @@
         "key": "miss_chance",
         "header": "MISS CHANCE:",
         "value": "70%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -20523,6 +24459,18 @@
         "key": "extra_duration",
         "header": "EXTRA DURATION:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -20624,6 +24572,12 @@
         "key": "scepter_movementspeed",
         "header": "SCEPTER BONUS MOVESPEED:",
         "value": "100"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.65",
+        "generated": true
       }
     ],
     "mc": [
@@ -20663,6 +24617,18 @@
         "key": "speed",
         "header": "SPEED:",
         "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
         "generated": true
       }
     ],
@@ -20712,6 +24678,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "600"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -20733,6 +24711,18 @@
         "key": "duration_unit",
         "header": "NON-HERO DURATION:",
         "value": "20"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -20863,6 +24853,24 @@
         "header": "ABILITYCHARGES:",
         "value": "0",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "2.75",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "120",
@@ -20942,6 +24950,18 @@
         "header": "ILLUSION INCOMING DAMAGE TOOLTIP:",
         "value": "200",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -21009,6 +25029,23 @@
           "42",
           "50"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DEBUFF DURATION:",
+        "value": "10"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -21074,6 +25111,23 @@
         "header": "MIN SLOW:",
         "value": "20",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "7"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -21138,6 +25192,18 @@
         "header": "FAKE BOLT DISTANCE:",
         "value": "675",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -21194,6 +25260,23 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "6",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "550",
+          "600",
+          "650",
+          "700"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -21303,6 +25386,18 @@
         "header": "MAGIC RESISTANCE:",
         "value": "25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -21342,6 +25437,22 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "500",
+          "750",
+          "1000",
+          "1250"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -21362,7 +25473,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Drawing mystical energies from the earth, a Meepo can teleport to another Meepo or itself after channeling for %abilitycastpoint% seconds, dealing damage in both the departure and arrival locations.",
+    "desc": "Drawing mystical energies from the earth, a Meepo can teleport to another Meepo or itself after channeling for 1.5 seconds, dealing damage in both the departure and arrival locations.",
     "attrib": [
       {
         "key": "radius",
@@ -21378,6 +25489,18 @@
           "110",
           "130"
         ]
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.5",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -21594,6 +25717,18 @@
         "header": "LATCH VISION:",
         "value": "150",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -21663,6 +25798,12 @@
         "header": "PROJECTILE SPEED:",
         "value": "550",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "110",
@@ -21706,6 +25847,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "12"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -21748,6 +25895,12 @@
         "key": "damage",
         "header": "DAMAGE PER SECOND:",
         "value": "75"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -21783,6 +25936,18 @@
         "header": "TREE RESPAWN SECONDS:",
         "value": "10",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "160",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -21816,6 +25981,18 @@
           "180",
           "240"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "475",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -21864,6 +26041,18 @@
         "key": "fireblast_damage",
         "header": "FIREBLAST DAMAGE:",
         "value": "275"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "475",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": "400",
@@ -21920,6 +26109,23 @@
         "key": "multicast_delay",
         "header": "MULTICAST DELAY:",
         "value": "0.6",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "700",
+          "800",
+          "900",
+          "1000"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
         "generated": true
       }
     ],
@@ -21980,6 +26186,18 @@
         "key": "multicast_bloodlust_aoe",
         "header": "MULTICAST BLOODLUST AOE:",
         "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
         "generated": true
       }
     ],
@@ -22068,6 +26286,29 @@
         "key": "str_steal_scepter",
         "header": "SCEPTER STRENGTH STEAL:",
         "value": "10"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": [
+          "21",
+          "24",
+          "27",
+          "30"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -22125,6 +26366,18 @@
           "12",
           "16"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -22192,6 +26445,18 @@
           "3",
           "2.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -22415,6 +26680,22 @@
         "header": "FALL DURATION:",
         "value": "0.3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "550",
+          "575",
+          "600",
+          "625"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "125",
@@ -22501,6 +26782,18 @@
         "key": "jump_delay",
         "header": "JUMP DELAY:",
         "value": "0.25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -22605,6 +26898,18 @@
         "key": "cooldown_scepter",
         "header": "SCEPTER COOLDOWN:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "25",
@@ -22702,6 +27007,18 @@
         "header": "SLOW AMOUNT:",
         "value": "100",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": [
@@ -22739,6 +27056,23 @@
           "1400",
           "1800"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "600",
+          "1000",
+          "1400",
+          "1800"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -22778,6 +27112,18 @@
           "3.8",
           "4.4"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": "70",
@@ -22822,6 +27168,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.05",
+        "generated": true
       }
     ],
     "mc": [
@@ -22886,6 +27244,18 @@
           "200",
           "260"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -22913,6 +27283,18 @@
           "4.5",
           "5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -22976,6 +27358,12 @@
         "key": "damage_reflect_pct",
         "header": "DAMAGE REFLECTED:",
         "value": "100%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "40",
@@ -23122,6 +27510,12 @@
         "key": "carapace_burrow_range_tooltip",
         "header": "BURROW SPIKED CARAPACE RANGE:",
         "value": "300"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.5",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/nyx_assassin_burrow_md.png"
@@ -23190,6 +27584,12 @@
         "header": "INVULN DURATION:",
         "value": "0.3",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.65",
+        "generated": true
       }
     ],
     "mc": [
@@ -23232,6 +27632,18 @@
         "key": "fake_ensnare_distance",
         "header": "FAKE ENSNARE DISTANCE:",
         "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.6",
         "generated": true
       }
     ],
@@ -23286,6 +27698,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/naga_siren_rip_tide_md.png"
@@ -23332,6 +27750,22 @@
         "key": "regen_rate_tooltip_scepter",
         "header": "SCEPTER HEALTH REGEN:",
         "value": "10%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "1000",
+          "1200",
+          "1400"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
       }
     ],
     "mc": [
@@ -23443,6 +27877,29 @@
           "400",
           "500"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1800",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": [
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -23484,6 +27941,22 @@
           "2.5",
           "3"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "400",
+          "500",
+          "600",
+          "700"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "160",
@@ -23558,6 +28031,18 @@
           "150"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": [
@@ -23608,6 +28093,18 @@
         "key": "duration",
         "header": "ENEMY DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -23678,6 +28175,18 @@
           "4",
           "3"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -23734,6 +28243,22 @@
           "150",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "475",
+          "550",
+          "625",
+          "700"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -23848,6 +28373,18 @@
           "400",
           "500"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -23905,6 +28442,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "625",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -23975,6 +28524,18 @@
         "key": "damage_max",
         "header": "DAMAGE MAX:",
         "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -24076,6 +28637,12 @@
         "key": "tooltip_scepter_total_familiars",
         "header": "SCEPTER FAMILIARS:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -24136,6 +28703,12 @@
           "175",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -24194,6 +28767,18 @@
           "175",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "160",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": "14",
@@ -24261,6 +28846,18 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -24342,6 +28939,18 @@
         "key": "spirit_duration",
         "header": "DURATION:",
         "value": "19"
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "19",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -24390,6 +28999,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -24424,6 +29039,12 @@
         "key": "return_time",
         "header": "RETURN TIME:",
         "value": "12"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "175",
@@ -24516,6 +29137,18 @@
         "key": "pulse_interval",
         "header": "PULSE INTERVAL:",
         "value": "0.1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "325",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.001",
         "generated": true
       }
     ],
@@ -24727,6 +29360,12 @@
         "header": "SPLIT SHOT BONUS RANGE:",
         "value": "100",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/medusa_split_shot_md.png"
@@ -24820,6 +29459,18 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -24853,6 +29504,12 @@
         "key": "absorption_pct",
         "header": "DAMAGE ABSORBED:",
         "value": "70%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/medusa_mana_shield_md.png"
@@ -24912,6 +29569,18 @@
         "key": "speed_boost",
         "header": "SPEED BOOST:",
         "value": "50%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -24977,6 +29646,12 @@
           "1.6",
           "2"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/troll_warlord_berserkers_rage_md.png"
@@ -25040,6 +29715,18 @@
         "header": "AXE COUNT:",
         "value": "5",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -25097,6 +29784,12 @@
         "key": "whirl_duration",
         "header": "WHIRL DURATION:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -25207,6 +29900,18 @@
         "key": "scepter_cast_range_tooltip",
         "header": "SCEPTER CAST RANGE:",
         "value": "525"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "525",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -25244,6 +29949,12 @@
           "140",
           "170"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -25291,6 +30002,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "190",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -25494,6 +30217,24 @@
         "header": "BASIC SLOW DURATION:",
         "value": "0.9",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "0.6875",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -25591,6 +30332,18 @@
         "header": "SELF MULTIPLIER:",
         "value": "2",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -25680,6 +30433,12 @@
         "key": "skewer_manacost",
         "header": "SCEPTER MANACOST:",
         "value": "40"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -25725,6 +30484,18 @@
         "key": "pull_duration",
         "header": "PULL DURATION:",
         "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "410",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -25791,6 +30562,18 @@
         "key": "duration",
         "header": "STAT LOSS DURATION:",
         "value": "14"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "70",
@@ -25844,6 +30627,23 @@
           "180",
           "220"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "850",
+          "1050",
+          "1250",
+          "1450"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -25979,6 +30779,18 @@
         "header": "SLOW HEALTH PERCENTAGE:",
         "value": "5",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -26067,6 +30879,18 @@
         "key": "slow_health_percentage",
         "header": "SLOW HEALTH PERCENTAGE:",
         "value": "5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -26168,6 +30992,18 @@
         "key": "radius_scepter",
         "header": "SCEPTER RADIUS:",
         "value": "825"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -26228,6 +31064,18 @@
         "key": "projectile_speed",
         "header": "PROJECTILE SPEED:",
         "value": "2400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "650",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -26316,6 +31164,12 @@
           "7",
           "9"
         ]
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "10",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/bristleback_warpath_md.png"
@@ -26377,6 +31231,17 @@
         "key": "shard_distance",
         "header": "SHARD DISTANCE:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "2000"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -26484,6 +31349,18 @@
         "header": "SNOWBALL GRAB RADIUS:",
         "value": "350",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1250",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -26542,6 +31419,12 @@
           "50",
           "60"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -26587,6 +31470,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -26637,6 +31532,18 @@
         "key": "push_length",
         "header": "PUSH LENGTH:",
         "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -26700,6 +31607,18 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": "350"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -26750,6 +31669,18 @@
         "key": "scepter_radius",
         "header": "SCEPTER RADIUS:",
         "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "875",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -26833,6 +31764,18 @@
         "header": "CREEP DAMAGE PCT:",
         "value": "75",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -26879,6 +31822,23 @@
         "key": "scepter_radius",
         "header": "SCEPTER RADIUS:",
         "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "700",
+          "750",
+          "800",
+          "850"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -26930,6 +31890,18 @@
         "key": "scepter_radius",
         "header": "SCEPTER RADIUS:",
         "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -26987,6 +31959,18 @@
         "header": "MISSILE SPEED:",
         "value": "1300",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -27018,6 +32002,18 @@
         "key": "radius",
         "header": "BURST RADIUS:",
         "value": "675"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -27200,6 +32196,24 @@
           "150",
           "200"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1.3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -27259,6 +32273,24 @@
       {
         "key": "animation_rate",
         "header": "ANIMATION RATE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1.3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
         "value": "0",
         "generated": true
       }
@@ -27363,6 +32395,18 @@
         "key": "scepter_magic_immune_per_hero",
         "header": "SCEPTER MAGIC IMMUNE PER HERO:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -27562,6 +32606,18 @@
           "6"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": [
@@ -27636,6 +32692,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "330"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -27676,6 +32744,18 @@
           "50",
           "60"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "110",
@@ -27760,6 +32840,18 @@
         "header": "VICTORY RANGE:",
         "value": "600",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -27813,6 +32905,18 @@
         "key": "radius_scepter",
         "header": "RADIUS SCEPTER:",
         "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -27873,6 +32977,18 @@
       {
         "key": "AbilityCharges",
         "header": "ABILITYCHARGES:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
         "value": "0",
         "generated": true
       }
@@ -27939,6 +33055,18 @@
         "header": "BLIND PCT:",
         "value": "50",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -27955,7 +33083,7 @@
     "behavior": "Point Target",
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Ember Spirit generates Fire Remnant charges every %charge_restore_time% seconds, with a max of %max_charges% charges. Releasing a charge sends a Fire Remnant that runs to the target location at 250% Ember Spirit's speed.  Using Activate Fire Remnant, Ember Spirit can dash out to his Remnants, dealing damage along the way and exploding them upon arrival.  The targeted Remnant will be arrived at last.",
+    "desc": "Ember Spirit generates Fire Remnant charges every 38 seconds, with a max of 3 charges. Releasing a charge sends a Fire Remnant that runs to the target location at 250% Ember Spirit's speed.  Using Activate Fire Remnant, Ember Spirit can dash out to his Remnants, dealing damage along the way and exploding them upon arrival.  The targeted Remnant will be arrived at last.",
     "attrib": [
       {
         "key": "speed_multiplier",
@@ -28007,6 +33135,40 @@
         "key": "scepter_mana_cost",
         "header": "SCEPTER MANA COST:",
         "value": "25"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": "38",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "38"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "3"
       }
     ],
     "mc": "0",
@@ -28068,6 +33230,18 @@
         "key": "scepter_mana_cost",
         "header": "SCEPTER MANA COST:",
         "value": "25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "99999",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -28145,6 +33319,18 @@
         "key": "remnant_smash_radius_tooltip",
         "header": "REMNANT SMASH RADIUS TOOLTIP:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
         "generated": true
       }
     ],
@@ -28225,6 +33411,18 @@
           "0.8",
           "1"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -28293,6 +33491,18 @@
         "header": "TOTAL PULL DISTANCE:",
         "value": "1400",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1100",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -28312,6 +33522,42 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "120"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1100",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": "25",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "25",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "7",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "7",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -28343,6 +33589,18 @@
         "key": "aoe",
         "header": "SHATTER RADIUS:",
         "value": "300"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "125",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -28407,6 +33665,18 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
         "generated": true
       }
     ],
@@ -28491,6 +33761,18 @@
         "header": "BUILDING DAMAGE:",
         "value": "33",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.6",
+        "generated": true
       }
     ],
     "mc": [
@@ -28542,6 +33824,18 @@
           "1.5",
           "1.8"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "750",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.45",
+        "generated": true
       }
     ],
     "mc": [
@@ -28625,6 +33919,12 @@
           "4",
           "5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/abyssal_underlord_atrophy_aura_md.png"
@@ -28650,6 +33950,18 @@
           "5",
           "4"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.6",
+        "generated": true
       }
     ],
     "mc": [
@@ -28724,6 +34036,18 @@
         "key": "range",
         "header": "RADIUS:",
         "value": "475"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -28776,6 +34100,12 @@
         "key": "illusion_incoming_damage_total_tooltip",
         "header": "ILLUSION DAMAGE TAKEN:",
         "value": "320%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
+        "generated": true
       }
     ],
     "mc": [
@@ -28873,6 +34203,12 @@
         "header": "SCEPTER SPAWN DELAY:",
         "value": "0.6",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -28905,6 +34241,18 @@
           "30%",
           "25%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "475",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.35",
+        "generated": true
       }
     ],
     "mc": [
@@ -28983,6 +34331,12 @@
         "key": "dive_duration",
         "header": "DIVE DURATION:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -29073,6 +34427,12 @@
         "key": "tick_interval",
         "header": "TICK INTERVAL:",
         "value": "1",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1400",
         "generated": true
       }
     ],
@@ -29171,6 +34531,23 @@
         "header": "TURN RATE:",
         "value": "25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1300",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "MAX DURATION:",
+        "value": "6"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -29205,7 +34582,7 @@
     "behavior": "No Target",
     "dmg_type": "Magical",
     "bkbpierce": "Yes",
-    "desc": "The Phoenix willingly ends its current life for the chance to be reborn. Transforms into a burning sun that scorches enemies in a huge area. The sun can be destroyed by attacks from enemy Heroes. After %abilityduration% seconds the sun explodes, stunning all nearby enemies while restoring Phoenix to full health and mana with refreshed abilities.\n\nDISPEL TYPE: Strong Dispel",
+    "desc": "The Phoenix willingly ends its current life for the chance to be reborn. Transforms into a burning sun that scorches enemies in a huge area. The sun can be destroyed by attacks from enemy Heroes. After 6 seconds the sun explodes, stunning all nearby enemies while restoring Phoenix to full health and mana with refreshed abilities.\n\nDISPEL TYPE: Strong Dispel",
     "attrib": [
       {
         "key": "aura_radius",
@@ -29252,6 +34629,23 @@
         "key": "cast_range_tooltip_scepter",
         "header": "SCEPTER CAST RANGE:",
         "value": "500"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "DURATION:",
+        "value": "6"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.01",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -29326,6 +34720,12 @@
         "header": "TICK INTERVAL:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1400",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -29342,7 +34742,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "CHANNELED - Gathers Oracle's power into a bolt of scouring energy that, when released, damages, roots, and purges enemies of buffs in an area around the target. If target is an ally it will only purge debuffs. Can be channeled for up to %abilitychanneltime% seconds. The root duration is equal to the time spent channeling.\n\nDISPEL TYPE: Basic Dispel",
+    "desc": "CHANNELED - Gathers Oracle's power into a bolt of scouring energy that, when released, damages, roots, and purges enemies of buffs in an area around the target. If target is an ally it will only purge debuffs. Can be channeled for up to 2.5 seconds. The root duration is equal to the time spent channeling.\n\nDISPEL TYPE: Basic Dispel",
     "attrib": [
       {
         "key": "damage",
@@ -29389,6 +34789,24 @@
         "key": "scepter_stun_percentage",
         "header": "SCEPTER STUN DURATION:",
         "value": "50%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "2.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -29423,6 +34841,22 @@
         "key": "magic_damage_resistance_pct_tooltip",
         "header": "MAGIC DAMAGE RESISTANCE PCT TOOLTIP:",
         "value": "100",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "500",
+          "600",
+          "700",
+          "800"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -29486,6 +34920,18 @@
         "header": "TICK RATE:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "850",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -29515,6 +34961,22 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": [
+          "700",
+          "850",
+          "1000"
+        ],
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -29583,6 +35045,18 @@
         "key": "strike_cast_range",
         "header": "DISTANCE:",
         "value": "1200"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -29612,6 +35086,12 @@
         "key": "invul_duration",
         "header": "INVUL DURATION:",
         "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -29720,6 +35200,18 @@
           "60%",
           "80%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -29772,6 +35264,24 @@
         "key": "impact_radius",
         "header": "IMPACT RADIUS:",
         "value": "375",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "1.7",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -29896,6 +35406,24 @@
         "key": "scepter_spawn_duration",
         "header": "SCEPTER SOLDIER DURATION:",
         "value": "12"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "13",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -30014,6 +35542,18 @@
         "key": "strikes",
         "header": "STRIKES:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -30098,6 +35638,18 @@
         "key": "jump_horizontal_distance",
         "header": "JUMP HORIZONTAL DISTANCE:",
         "value": "225",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -30274,6 +35826,18 @@
         "header": "JUMP RECOVER TIME:",
         "value": "0.25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -30362,6 +35926,18 @@
         "key": "initial_creation_delay",
         "header": "INITIAL CREATION DELAY:",
         "value": "0.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -30475,6 +36051,18 @@
         "header": "STARTING HEIGHT:",
         "value": "300",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -30526,6 +36114,12 @@
         "header": "SCEPTER RADIUS:",
         "value": "900",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -30567,6 +36161,18 @@
         "key": "stun_radius",
         "header": "STUN RADIUS:",
         "value": "325"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -30653,6 +36259,17 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1400"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.8",
+        "generated": true
       }
     ],
     "mc": [
@@ -30774,6 +36391,18 @@
         "key": "latched_unit_offset_short",
         "header": "LATCHED UNIT OFFSET SHORT:",
         "value": "95",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -30910,6 +36539,22 @@
           "45",
           "55"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "400",
+          "525",
+          "650",
+          "775"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
+        "generated": true
       }
     ],
     "mc": [
@@ -30971,6 +36616,21 @@
         "key": "creep_duration_pct",
         "header": "CREEP DURATION PCT:",
         "value": "50",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "700",
+          "800",
+          "900"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
         "generated": true
       }
     ],
@@ -31061,6 +36721,12 @@
         "header": "KNOCKBACK DISTANCE:",
         "value": "75",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.25",
+        "generated": true
       }
     ],
     "mc": [
@@ -31139,6 +36805,18 @@
         "key": "scepter_cooldown",
         "header": "SCEPTER COOLDOWN:",
         "value": "3.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": [
@@ -31291,6 +36969,18 @@
         "header": "WARRIOR FADE MAX DIST:",
         "value": "450",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -31414,6 +37104,18 @@
         "header": "THINK INTERVAL:",
         "value": "0.1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": [
@@ -31476,6 +37178,12 @@
         "key": "damage_radius",
         "header": "DAMAGE RADIUS:",
         "value": "275",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
         "generated": true
       }
     ],
@@ -31555,6 +37263,42 @@
           "60%",
           "80%"
         ]
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": [
+          "30",
+          "25",
+          "20"
+        ],
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": [
+          "30",
+          "25",
+          "20"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "2",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "2"
       }
     ],
     "mc": "100",
@@ -31636,6 +37380,18 @@
         "key": "silence_duration_scepter",
         "header": "SILENCE DURATION SCEPTER:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -31729,6 +37485,18 @@
         "key": "point_blank_dmg_bonus_pct",
         "header": "POINT BLANK DMG BONUS PCT:",
         "value": "50",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
         "generated": true
       }
     ],
@@ -31869,6 +37637,24 @@
         "header": "BURN LINGER DURATION:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "6",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": [
@@ -31892,6 +37678,18 @@
         "key": "max_time_in_belly",
         "header": "MAX TIME IN BELLY:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -32010,6 +37808,18 @@
         "header": "MAX ACCELERATION:",
         "value": "2000",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "3000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "150",
@@ -32093,6 +37903,18 @@
         "header": "SELF CAST DELAY:",
         "value": "0.3",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -32168,6 +37990,24 @@
         "key": "slow_duration",
         "header": "ATTACK SLOW DURATION:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilityduration",
+        "header": "ABILITYDURATION:",
+        "value": "8",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -32382,6 +38222,17 @@
         "key": "burn_as_damage_tooltip",
         "header": "CONVERTED TO DAMAGE:",
         "value": "100%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "600"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -32403,6 +38254,17 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "600"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "cd": "15",
@@ -32795,6 +38657,12 @@
         "key": "hero_stun_duration",
         "header": "HERO STUN:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -32826,6 +38694,12 @@
         "key": "armor_reduction_pct",
         "header": "BASE ARMOR REDUCTION:",
         "value": "50%"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -32852,6 +38726,12 @@
         "key": "damage",
         "header": "PETRIFY DPS:",
         "value": "75"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
       }
     ],
     "cd": "15",
@@ -32935,6 +38815,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "3"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -32977,6 +38863,18 @@
         "key": "slow_duration",
         "header": "SLOW DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.56",
+        "generated": true
       }
     ],
     "mc": "40",
@@ -32999,6 +38897,18 @@
         "header": "NET SPEED:",
         "value": "1500",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "550",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -33014,6 +38924,12 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "40"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -33085,6 +39001,18 @@
         "key": "speed",
         "header": "SPEED:",
         "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -33204,6 +39132,24 @@
         "key": "duration",
         "header": "MAX DURATION:",
         "value": "40"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "500",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "40",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.4",
+        "generated": true
       }
     ],
     "mc": "200",
@@ -33293,6 +39239,18 @@
         "header": "SUMMON DAMAGE:",
         "value": "400",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "120",
@@ -33309,6 +39267,18 @@
         "key": "burn_amount",
         "header": "MANA BURNED:",
         "value": "100"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -33347,6 +39317,18 @@
         "key": "distance",
         "header": "TRAVEL DISTANCE:",
         "value": "1380"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "700",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -33426,6 +39408,18 @@
         "key": "health",
         "header": "HEALTH RESTORED:",
         "value": "15"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.5",
+        "generated": true
       }
     ],
     "mc": "5",
@@ -33463,6 +39457,18 @@
         "key": "max_targets",
         "header": "MAX TARGETS:",
         "value": "4"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -33539,6 +39545,18 @@
         "key": "burn_interval",
         "header": "BURN INTERVAL:",
         "value": "0.5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -33710,6 +39728,12 @@
         "key": "hero_duration",
         "header": "HERO DURATION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -33730,6 +39754,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "8"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "50",
@@ -33861,6 +39897,18 @@
         "header": "GAME END DAMAGE:",
         "value": "100000",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -33946,6 +39994,18 @@
         "header": "TOSS DAMAGE:",
         "value": "500",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -33996,6 +40056,18 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": "3000"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -34039,6 +40111,24 @@
         "key": "projectile_count",
         "header": "PROJECTILE COUNT:",
         "value": "20",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitychanneltime",
+        "header": "ABILITYCHANNELTIME:",
+        "value": "2.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1.5",
         "generated": true
       }
     ],
@@ -34090,7 +40180,20 @@
     "behavior": "No Target",
     "dmg_type": "Magical",
     "desc": "Roshan calls a group of Roshlings to aid him.",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
+      }
+    ],
     "mc": "0",
     "cd": "30",
     "img": "/apps/dota2/images/abilities/roshan_halloween_summon_md.png"
@@ -34123,6 +40226,18 @@
         "key": "damage_percent",
         "header": "DAMAGE PERCENT:",
         "value": "50",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "3",
         "generated": true
       }
     ],
@@ -35738,6 +41853,42 @@
         "header": "ABILITYCHARGERESTORETIME:",
         "value": "0",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "100",
+        "generated": true
+      },
+      {
+        "key": "abilitychargerestoretime",
+        "header": "ABILITYCHARGERESTORETIME:",
+        "value": "23",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "23",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycharges",
+        "header": "ABILITYCHARGES:",
+        "value": "3",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": "3",
+        "generated": true
       }
     ],
     "mc": [
@@ -35806,6 +41957,18 @@
         "key": "cast_range_scepter_bonus",
         "header": "BONUS SCEPTER CAST RANGE:",
         "value": "300"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "150",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
       }
     ],
     "mc": [
@@ -35867,6 +42030,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "0.75",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
         "generated": true
       }
     ],
@@ -35966,6 +42141,17 @@
         "header": "DETONATE DELAY:",
         "value": "0.25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "500"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "1",
+        "generated": true
       }
     ],
     "mc": [
@@ -35993,6 +42179,12 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "700"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": "1",
@@ -36016,6 +42208,12 @@
           "425"
         ],
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
       }
     ],
     "img": "/apps/dota2/images/abilities/techies_remote_mines_self_detonate_md.png"
@@ -36038,6 +42236,18 @@
         "key": "lifetime",
         "header": "SIGN DURATION:",
         "value": "180"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "10",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -36372,6 +42582,12 @@
         "key": "mana_cost_scepter",
         "header": "SCEPTER MANA PER SECOND:",
         "value": "30"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "90",
@@ -36437,6 +42653,18 @@
         "header": "SECONDARY PROJECTILE SPEED:",
         "value": "650",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -36477,6 +42705,18 @@
           "4%",
           "5%"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -36531,6 +42771,18 @@
           "4.75",
           "5.5"
         ]
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "250",
@@ -36576,6 +42828,12 @@
         "key": "tooltip_scepter_manacost",
         "header": "MANA COST:",
         "value": "100"
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
+        "generated": true
       }
     ],
     "mc": "100",
@@ -36629,6 +42887,22 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": "0"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": [
+          "500",
+          "600",
+          "700",
+          "800"
+        ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "75",
@@ -36672,6 +42946,18 @@
         "key": "evasion_chance",
         "header": "EVASION BONUS:",
         "value": "100%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "900",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": [
@@ -36755,6 +43041,18 @@
         "key": "move_speed_slow_pct",
         "header": "MOVEMENT SLOW:",
         "value": "100%"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "2000",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "80",
@@ -36783,6 +43081,12 @@
           "240",
           "300"
         ]
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.15",
+        "generated": true
       }
     ],
     "cd": [
@@ -39892,6 +46196,18 @@
         "header": "SPEED:",
         "value": "1000",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -39930,6 +46246,18 @@
         "key": "think_interval",
         "header": "THINK INTERVAL:",
         "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "350",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
         "generated": true
       }
     ],
@@ -40048,6 +46376,18 @@
         "header": "BUMP DELAY ABSOLUTE:",
         "value": "0.25",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40067,6 +46407,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "165",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
         "generated": true
       }
     ],
@@ -40101,6 +46453,18 @@
         "header": "LINGER DURATION:",
         "value": "5",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40133,6 +46497,18 @@
         "key": "snowball_stun_duration",
         "header": "STUN DURATION:",
         "value": "5"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40168,6 +46544,18 @@
         "key": "taunt_duration",
         "header": "TAUNT DURATION:",
         "value": "2"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40198,6 +46586,18 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": "500"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "cd": "30",
@@ -40248,6 +46648,18 @@
         "key": "miss_rate",
         "header": "BLIND MISS CHANCE:",
         "value": "100"
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.3",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40447,6 +46859,12 @@
         "header": "ACKNOWLEDGED COOLDOWN:",
         "value": "1",
         "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40517,6 +46935,18 @@
         "header": "BOUNCE DELAY:",
         "value": "0.6",
         "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.2",
+        "generated": true
       }
     ],
     "mc": "0",
@@ -40548,6 +46978,18 @@
         "key": "lifetime",
         "header": "LIFETIME:",
         "value": "300",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -40590,6 +47032,18 @@
         "key": "duration",
         "header": "DURATION:",
         "value": "30",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],
@@ -40659,6 +47113,18 @@
         "key": "debuff_time",
         "header": "DEBUFF TIME:",
         "value": "2.5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "ABILITYCASTRANGE:",
+        "value": "400",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "ABILITYCASTPOINT:",
+        "value": "0.1",
         "generated": true
       }
     ],

--- a/build/items.json
+++ b/build/items.json
@@ -4,7 +4,7 @@
       "Active: Blink Teleport to a target point up to 1200 units away. Blink Dagger cannot be used for 3 seconds after taking damage from an enemy hero or Roshan."
     ],
     "id": 1,
-    "img": "/apps/dota2/images/items/blink_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/blink_lg.png?t=1592658656576",
     "dname": "Blink Dagger",
     "qual": "component",
     "cost": 2250,
@@ -19,7 +19,7 @@
   },
   "blades_of_attack": {
     "id": 2,
-    "img": "/apps/dota2/images/items/blades_of_attack_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/blades_of_attack_lg.png?t=1592658656576",
     "dname": "Blades of Attack",
     "qual": "component",
     "cost": 450,
@@ -41,7 +41,7 @@
   },
   "broadsword": {
     "id": 3,
-    "img": "/apps/dota2/images/items/broadsword_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/broadsword_lg.png?t=1592658656576",
     "dname": "Broadsword",
     "qual": "component",
     "cost": 1000,
@@ -63,7 +63,7 @@
   },
   "chainmail": {
     "id": 4,
-    "img": "/apps/dota2/images/items/chainmail_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/chainmail_lg.png?t=1592658656576",
     "dname": "Chainmail",
     "qual": "component",
     "cost": 550,
@@ -85,7 +85,7 @@
   },
   "claymore": {
     "id": 5,
-    "img": "/apps/dota2/images/items/claymore_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/claymore_lg.png?t=1592658656576",
     "dname": "Claymore",
     "qual": "component",
     "cost": 1400,
@@ -107,7 +107,7 @@
   },
   "helm_of_iron_will": {
     "id": 6,
-    "img": "/apps/dota2/images/items/helm_of_iron_will_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/helm_of_iron_will_lg.png?t=1592658656576",
     "dname": "Helm of Iron Will",
     "qual": "component",
     "cost": 925,
@@ -138,7 +138,7 @@
       "Passive: PierceGrants each attack a 25% chance to pierce through evasion and deal 80 bonus magical damage."
     ],
     "id": 7,
-    "img": "/apps/dota2/images/items/javelin_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/javelin_lg.png?t=1592658656576",
     "dname": "Javelin",
     "qual": "component",
     "cost": 1100,
@@ -153,7 +153,7 @@
   },
   "mithril_hammer": {
     "id": 8,
-    "img": "/apps/dota2/images/items/mithril_hammer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mithril_hammer_lg.png?t=1592658656576",
     "dname": "Mithril Hammer",
     "qual": "component",
     "cost": 1600,
@@ -175,7 +175,7 @@
   },
   "platemail": {
     "id": 9,
-    "img": "/apps/dota2/images/items/platemail_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/platemail_lg.png?t=1592658656576",
     "dname": "Platemail",
     "qual": "secret_shop",
     "cost": 1400,
@@ -197,7 +197,7 @@
   },
   "quarterstaff": {
     "id": 10,
-    "img": "/apps/dota2/images/items/quarterstaff_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/quarterstaff_lg.png?t=1592658656576",
     "dname": "Quarterstaff",
     "qual": "component",
     "cost": 875,
@@ -225,11 +225,11 @@
   },
   "quelling_blade": {
     "hint": [
-      "Active: Chop Tree Destroy a target tree. Cast Range: %abilitycastrange%",
+      "Active: Chop Tree Destroy a target tree. Cast Range: 350",
       "Passive: Quell Increases attack damage against non-hero units by 18 for melee heroes, and 5 for ranged."
     ],
     "id": 11,
-    "img": "/apps/dota2/images/items/quelling_blade_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/quelling_blade_lg.png?t=1592658656576",
     "dname": "Quelling Blade",
     "qual": "component",
     "cost": 150,
@@ -247,7 +247,7 @@
       "Use: Imbue Instantly restores 85 health."
     ],
     "id": 237,
-    "img": "/apps/dota2/images/items/faerie_fire_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/faerie_fire_lg.png?t=1592658656576",
     "dname": "Faerie Fire",
     "qual": "consumable",
     "cost": 70,
@@ -272,7 +272,7 @@
       "Passive: Magical Damage Block Consumes a charge to block 120 magic damage from damage instances over 50 damage. Comes with 6 charges. When the charges are gone, the item disappears."
     ],
     "id": 265,
-    "img": "/apps/dota2/images/items/infused_raindrop_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/infused_raindrop_lg.png?t=1592658656576",
     "dname": "Infused Raindrops",
     "qual": "component",
     "cost": 225,
@@ -297,7 +297,7 @@
       "Bonuses from multiple Wind Laces do not stack."
     ],
     "id": 244,
-    "img": "/apps/dota2/images/items/wind_lace_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/wind_lace_lg.png?t=1592658656576",
     "dname": "Wind Lace",
     "qual": "component",
     "cost": 250,
@@ -319,7 +319,7 @@
   },
   "ring_of_protection": {
     "id": 12,
-    "img": "/apps/dota2/images/items/ring_of_protection_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_protection_lg.png?t=1592658656576",
     "dname": "Ring of Protection",
     "qual": "component",
     "cost": 150,
@@ -344,7 +344,7 @@
       "Passive: Damage BlockGrants a 50% chance to block 20 damage from incoming attacks on melee heroes, and 8 damage on ranged."
     ],
     "id": 182,
-    "img": "/apps/dota2/images/items/stout_shield_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/stout_shield_lg.png?t=1592658656576",
     "dname": "Stout Shield",
     "qual": "component",
     "cost": 100,
@@ -363,7 +363,7 @@
       "Passive: Shade SightGrants 400 bonus night vision."
     ],
     "id": 247,
-    "img": "/apps/dota2/images/items/moon_shard_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/moon_shard_lg.png?t=1592658656576",
     "dname": "Moon Shard",
     "qual": "consumable",
     "cost": 4000,
@@ -388,7 +388,7 @@
   },
   "gauntlets": {
     "id": 13,
-    "img": "/apps/dota2/images/items/gauntlets_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/gauntlets_lg.png?t=1592658656576",
     "dname": "Gauntlets of Strength",
     "qual": "component",
     "cost": 145,
@@ -410,7 +410,7 @@
   },
   "slippers": {
     "id": 14,
-    "img": "/apps/dota2/images/items/slippers_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/slippers_lg.png?t=1592658656576",
     "dname": "Slippers of Agility",
     "qual": "component",
     "cost": 145,
@@ -432,7 +432,7 @@
   },
   "mantle": {
     "id": 15,
-    "img": "/apps/dota2/images/items/mantle_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mantle_lg.png?t=1592658656576",
     "dname": "Mantle of Intelligence",
     "qual": "component",
     "cost": 145,
@@ -454,10 +454,10 @@
   },
   "branches": {
     "hint": [
-      "Use: Plant Tree Targets the ground to plant a happy little tree that lasts for 20 seconds.Range: %abilitycastrange%"
+      "Use: Plant Tree Targets the ground to plant a happy little tree that lasts for 20 seconds.Range: 400"
     ],
     "id": 16,
-    "img": "/apps/dota2/images/items/branches_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/branches_lg.png?t=1592658656576",
     "dname": "Iron Branch",
     "qual": "consumable",
     "cost": 50,
@@ -479,7 +479,7 @@
   },
   "belt_of_strength": {
     "id": 17,
-    "img": "/apps/dota2/images/items/belt_of_strength_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/belt_of_strength_lg.png?t=1592658656576",
     "dname": "Belt of Strength",
     "qual": "component",
     "cost": 450,
@@ -501,7 +501,7 @@
   },
   "boots_of_elves": {
     "id": 18,
-    "img": "/apps/dota2/images/items/boots_of_elves_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/boots_of_elves_lg.png?t=1592658656576",
     "dname": "Band of Elvenskin",
     "qual": "component",
     "cost": 450,
@@ -523,7 +523,7 @@
   },
   "robe": {
     "id": 19,
-    "img": "/apps/dota2/images/items/robe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/robe_lg.png?t=1592658656576",
     "dname": "Robe of the Magi",
     "qual": "component",
     "cost": 450,
@@ -545,7 +545,7 @@
   },
   "circlet": {
     "id": 20,
-    "img": "/apps/dota2/images/items/circlet_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/circlet_lg.png?t=1592658656576",
     "dname": "Circlet",
     "qual": "component",
     "cost": 155,
@@ -567,7 +567,7 @@
   },
   "crown": {
     "id": 261,
-    "img": "/apps/dota2/images/items/crown_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/crown_lg.png?t=1592658656576",
     "dname": "Crown",
     "qual": "component",
     "cost": 450,
@@ -589,7 +589,7 @@
   },
   "ogre_axe": {
     "id": 21,
-    "img": "/apps/dota2/images/items/ogre_axe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ogre_axe_lg.png?t=1592658656576",
     "dname": "Ogre Axe",
     "qual": "component",
     "cost": 1000,
@@ -611,7 +611,7 @@
   },
   "blade_of_alacrity": {
     "id": 22,
-    "img": "/apps/dota2/images/items/blade_of_alacrity_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/blade_of_alacrity_lg.png?t=1592658656576",
     "dname": "Blade of Alacrity",
     "qual": "component",
     "cost": 1000,
@@ -633,7 +633,7 @@
   },
   "staff_of_wizardry": {
     "id": 23,
-    "img": "/apps/dota2/images/items/staff_of_wizardry_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/staff_of_wizardry_lg.png?t=1592658656576",
     "dname": "Staff of Wizardry",
     "qual": "component",
     "cost": 1000,
@@ -655,7 +655,7 @@
   },
   "ultimate_orb": {
     "id": 24,
-    "img": "/apps/dota2/images/items/ultimate_orb_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ultimate_orb_lg.png?t=1592658656576",
     "dname": "Ultimate Orb",
     "qual": "secret_shop",
     "cost": 2150,
@@ -677,7 +677,7 @@
   },
   "gloves": {
     "id": 25,
-    "img": "/apps/dota2/images/items/gloves_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/gloves_lg.png?t=1592658656576",
     "dname": "Gloves of Haste",
     "qual": "component",
     "cost": 450,
@@ -702,7 +702,7 @@
       "Passive: LifestealHeals the attacker for 15% of attack damage dealt."
     ],
     "id": 26,
-    "img": "/apps/dota2/images/items/lifesteal_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/lifesteal_lg.png?t=1592658656576",
     "dname": "Morbid Mask",
     "qual": "component",
     "cost": 900,
@@ -717,7 +717,7 @@
   },
   "ring_of_regen": {
     "id": 27,
-    "img": "/apps/dota2/images/items/ring_of_regen_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_regen_lg.png?t=1592658656576",
     "dname": "Ring of Regen",
     "qual": "component",
     "cost": 225,
@@ -739,7 +739,7 @@
   },
   "ring_of_tarrasque": {
     "id": 279,
-    "img": "/apps/dota2/images/items/ring_of_tarrasque_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_tarrasque_lg.png?t=1592658656576",
     "dname": "Ring of Tarrasque",
     "qual": "component",
     "cost": 650,
@@ -767,7 +767,7 @@
   },
   "sobi_mask": {
     "id": 28,
-    "img": "/apps/dota2/images/items/sobi_mask_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/sobi_mask_lg.png?t=1592658656576",
     "dname": "Sage's Mask",
     "qual": "component",
     "cost": 225,
@@ -792,7 +792,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 29,
-    "img": "/apps/dota2/images/items/boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/boots_lg.png?t=1592658656576",
     "dname": "Boots of Speed",
     "qual": "component",
     "cost": 500,
@@ -818,7 +818,7 @@
       "Passive: EverlastingDropped on death, and cannot be destroyed."
     ],
     "id": 30,
-    "img": "/apps/dota2/images/items/gem_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/gem_lg.png?t=1592658656576",
     "dname": "Gem of True Sight",
     "qual": "component",
     "cost": 900,
@@ -833,7 +833,7 @@
   },
   "cloak": {
     "id": 31,
-    "img": "/apps/dota2/images/items/cloak_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/cloak_lg.png?t=1592658656576",
     "dname": "Cloak",
     "qual": "component",
     "cost": 550,
@@ -855,7 +855,7 @@
   },
   "talisman_of_evasion": {
     "id": 32,
-    "img": "/apps/dota2/images/items/talisman_of_evasion_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/talisman_of_evasion_lg.png?t=1592658656576",
     "dname": "Talisman of Evasion",
     "qual": "secret_shop",
     "cost": 1400,
@@ -880,7 +880,7 @@
       "Use: Fondue Instantly restores 2500 health and 1500 mana."
     ],
     "id": 33,
-    "img": "/apps/dota2/images/items/cheese_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/cheese_lg.png?t=1592658656576",
     "dname": "Cheese",
     "qual": "consumable",
     "cost": 1000,
@@ -898,7 +898,7 @@
       "Active: Energy Charge Instantly restores 15 health and mana per charge stored. Max 10 charges. Gains a charge whenever a visible enemy within 1200 range uses an ability."
     ],
     "id": 34,
-    "img": "/apps/dota2/images/items/magic_stick_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/magic_stick_lg.png?t=1592658656576",
     "dname": "Magic Stick",
     "qual": "component",
     "cost": 200,
@@ -913,7 +913,7 @@
   },
   "recipe_magic_wand": {
     "id": 35,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Magic Wand Recipe",
     "cost": 150,
     "notes": "",
@@ -930,7 +930,7 @@
       "Active: Energy ChargeInstantly restores 15 health and mana per charge stored. Max 20 charges. Gains a charge whenever a visible enemy within 1200 range uses an ability."
     ],
     "id": 36,
-    "img": "/apps/dota2/images/items/magic_wand_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/magic_wand_lg.png?t=1592658656576",
     "dname": "Magic Wand",
     "qual": "common",
     "cost": 450,
@@ -959,7 +959,7 @@
       "Active: Ghost Form You enter ghost form for 4 seconds, becoming immune to physical damage, but are unable to attack and -40% more vulnerable to magic damage."
     ],
     "id": 37,
-    "img": "/apps/dota2/images/items/ghost_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ghost_lg.png?t=1592658656576",
     "dname": "Ghost Scepter",
     "qual": "component",
     "cost": 1500,
@@ -981,10 +981,10 @@
   },
   "clarity": {
     "hint": [
-      "Use: Replenish Grants 6 mana regeneration to the target for 30 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: %abilitycastrange%"
+      "Use: Replenish Grants 6 mana regeneration to the target for 30 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: 250"
     ],
     "id": 38,
-    "img": "/apps/dota2/images/items/clarity_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/clarity_lg.png?t=1592658656576",
     "dname": "Clarity",
     "qual": "consumable",
     "cost": 50,
@@ -999,10 +999,10 @@
   },
   "enchanted_mango": {
     "hint": [
-      "Use: Eat Mango Instantly restores 110 mana.Range: %abilitycastrange%"
+      "Use: Eat Mango Instantly restores 110 mana.Range: 400"
     ],
     "id": 216,
-    "img": "/apps/dota2/images/items/enchanted_mango_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/enchanted_mango_lg.png?t=1592658656576",
     "dname": "Enchanted Mango",
     "qual": "consumable",
     "cost": 70,
@@ -1024,10 +1024,10 @@
   },
   "flask": {
     "hint": [
-      "Use: Salve Grants 40 health regeneration to the target for 10 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: %abilitycastrange%"
+      "Use: Salve Grants 40 health regeneration to the target for 10 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: 250"
     ],
     "id": 39,
-    "img": "/apps/dota2/images/items/flask_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/flask_lg.png?t=1592658656576",
     "dname": "Healing Salve",
     "qual": "consumable",
     "cost": 110,
@@ -1045,7 +1045,7 @@
       "Use: RevealReveals and slows invisible heroes by -20% in a 1050 radius around the caster for 12 seconds."
     ],
     "id": 40,
-    "img": "/apps/dota2/images/items/dust_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dust_lg.png?t=1592658656576",
     "dname": "Dust of Appearance",
     "qual": "consumable",
     "cost": 80,
@@ -1060,11 +1060,11 @@
   },
   "bottle": {
     "hint": [
-      "Active: RegenerateConsumes a charge to restore 125 health and 75 mana over 2.5 seconds. If the hero is attacked by an enemy hero or Roshan, the effect is lost.The Bottle automatically refills at the fountain.Hold Control to use on an allied hero.Range: %abilitycastrange%",
+      "Active: RegenerateConsumes a charge to restore 125 health and 75 mana over 2.5 seconds. If the hero is attacked by an enemy hero or Roshan, the effect is lost.The Bottle automatically refills at the fountain.Hold Control to use on an allied hero.Range: 350",
       "Passive:  Store RuneRunes can be stored in the bottle for later use by right-clicking them. Unused runes will automatically activate after 2 minutes.Using a stored rune fully refills the Bottle."
     ],
     "id": 41,
-    "img": "/apps/dota2/images/items/bottle_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/bottle_lg.png?t=1592658656576",
     "dname": "Bottle",
     "qual": "common",
     "cost": 625,
@@ -1079,10 +1079,10 @@
   },
   "ward_observer": {
     "hint": [
-      "Use: PlantPlants an Observer Ward, an invisible watcher that gives ground vision in a 1400 radius to your team. Lasts 6 minutes.Hold Control to give one Observer Ward to an allied hero.Range: %abilitycastrange%"
+      "Use: PlantPlants an Observer Ward, an invisible watcher that gives ground vision in a 1400 radius to your team. Lasts 6 minutes.Hold Control to give one Observer Ward to an allied hero.Range: 500"
     ],
     "id": 42,
-    "img": "/apps/dota2/images/items/ward_observer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ward_observer_lg.png?t=1592658656576",
     "dname": "Observer Ward",
     "qual": "consumable",
     "cost": 0,
@@ -1104,10 +1104,10 @@
   },
   "ward_sentry": {
     "hint": [
-      "Use: Plant Plants a Sentry Ward, an invisible watcher that grants True Sight, the ability to see invisible enemy units and wards, to any existing allied vision within a 1000 radius.Lasts 8 minutes.Does not grant ground vision.Hold Control to give one Sentry Ward to an allied hero.Range: %abilitycastrange%"
+      "Use: Plant Plants a Sentry Ward, an invisible watcher that grants True Sight, the ability to see invisible enemy units and wards, to any existing allied vision within a 1000 radius.Lasts 8 minutes.Does not grant ground vision.Hold Control to give one Sentry Ward to an allied hero.Range: 500"
     ],
     "id": 43,
-    "img": "/apps/dota2/images/items/ward_sentry_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ward_sentry_lg.png?t=1592658656576",
     "dname": "Sentry Ward",
     "qual": "consumable",
     "cost": 75,
@@ -1129,10 +1129,10 @@
   },
   "ward_dispenser": {
     "hint": [
-      "Use: Plant Plant the currently active ward.  Double-Click to switch the currently active ward.Range: %abilitycastrange%"
+      "Use: Plant Plant the currently active ward.  Double-Click to switch the currently active ward.Range: 500"
     ],
     "id": 218,
-    "img": "/apps/dota2/images/items/ward_dispenser_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ward_dispenser_lg.png?t=1592658656576",
     "dname": "Observer and Sentry Wards",
     "qual": "common",
     "cost": 75,
@@ -1171,10 +1171,10 @@
   },
   "tango": {
     "hint": [
-      "Use: Devour Consumes a target tree to gain 7 health regeneration for 16 seconds. Consuming an Ironwood Tree doubles the heal amount.Comes with 3 charges.  Can be used on an allied hero to give them one Tango.Tree Range: %abilitycastrange%"
+      "Use: Devour Consumes a target tree to gain 7 health regeneration for 16 seconds. Consuming an Ironwood Tree doubles the heal amount.Comes with 3 charges.  Can be used on an allied hero to give them one Tango.Tree Range: 165"
     ],
     "id": 44,
-    "img": "/apps/dota2/images/items/tango_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tango_lg.png?t=1592658656576",
     "dname": "Tango",
     "qual": "consumable",
     "cost": 90,
@@ -1189,10 +1189,10 @@
   },
   "tango_single": {
     "hint": [
-      "Use: Devour Consumes a target tree to gain 7 health regeneration for 16 seconds. Consuming an Ironwood Tree doubles the heal amount.Tree Range: %abilitycastrange%"
+      "Use: Devour Consumes a target tree to gain 7 health regeneration for 16 seconds. Consuming an Ironwood Tree doubles the heal amount.Tree Range: 165"
     ],
     "id": 241,
-    "img": "/apps/dota2/images/items/tango_single_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tango_single_lg.png?t=1592658656576",
     "dname": "Tango (Shared)",
     "qual": "consumable",
     "cost": 30,
@@ -1210,7 +1210,7 @@
       "Use: Deploy Courier Deploys a creature to carry items to and from your team's base."
     ],
     "id": 45,
-    "img": "/apps/dota2/images/items/courier_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/courier_lg.png?t=1592658656576",
     "dname": "Animal Courier",
     "qual": "consumable",
     "cost": 50,
@@ -1228,7 +1228,7 @@
       "Use: Upgrade CourierUpgrades your team's Animal Courier to a Flying Courier, granting it swift, unobstructed movement to carry items to and from your team's base. Requires a deployed Animal Courier."
     ],
     "id": 286,
-    "img": "/apps/dota2/images/items/flying_courier_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/flying_courier_lg.png?t=1592658656576",
     "dname": "Flying Courier",
     "qual": "consumable",
     "cost": 100,
@@ -1246,7 +1246,7 @@
       "Use: TeleportAfter channeling for 3 seconds, teleports you to a target friendly building. Double-click to teleport to your team's base fountain."
     ],
     "id": 46,
-    "img": "/apps/dota2/images/items/tpscroll_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tpscroll_lg.png?t=1592658656576",
     "dname": "Town Portal Scroll",
     "qual": "consumable",
     "cost": 90,
@@ -1261,7 +1261,7 @@
   },
   "recipe_travel_boots": {
     "id": 47,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Boots of Travel Recipe",
     "cost": 2000,
     "notes": "",
@@ -1279,7 +1279,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 48,
-    "img": "/apps/dota2/images/items/travel_boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/travel_boots_lg.png?t=1592658656576",
     "dname": "Boots of Travel",
     "qual": "common",
     "cost": 2500,
@@ -1312,7 +1312,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 220,
-    "img": "/apps/dota2/images/items/travel_boots_2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/travel_boots_2_lg.png?t=1592658656576",
     "dname": "Boots of Travel",
     "qual": "common",
     "cost": 4500,
@@ -1346,7 +1346,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 50,
-    "img": "/apps/dota2/images/items/phase_boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/phase_boots_lg.png?t=1592658656576",
     "dname": "Phase Boots",
     "qual": "common",
     "cost": 1500,
@@ -1388,7 +1388,7 @@
   },
   "demon_edge": {
     "id": 51,
-    "img": "/apps/dota2/images/items/demon_edge_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/demon_edge_lg.png?t=1592658656576",
     "dname": "Demon Edge",
     "qual": "secret_shop",
     "cost": 2200,
@@ -1410,7 +1410,7 @@
   },
   "eagle": {
     "id": 52,
-    "img": "/apps/dota2/images/items/eagle_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/eagle_lg.png?t=1592658656576",
     "dname": "Eaglesong",
     "qual": "secret_shop",
     "cost": 3000,
@@ -1432,7 +1432,7 @@
   },
   "reaver": {
     "id": 53,
-    "img": "/apps/dota2/images/items/reaver_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/reaver_lg.png?t=1592658656576",
     "dname": "Reaver",
     "qual": "secret_shop",
     "cost": 3000,
@@ -1454,7 +1454,7 @@
   },
   "relic": {
     "id": 54,
-    "img": "/apps/dota2/images/items/relic_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/relic_lg.png?t=1592658656576",
     "dname": "Sacred Relic",
     "qual": "secret_shop",
     "cost": 3800,
@@ -1476,7 +1476,7 @@
   },
   "hyperstone": {
     "id": 55,
-    "img": "/apps/dota2/images/items/hyperstone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/hyperstone_lg.png?t=1592658656576",
     "dname": "Hyperstone",
     "qual": "secret_shop",
     "cost": 2000,
@@ -1498,7 +1498,7 @@
   },
   "ring_of_health": {
     "id": 56,
-    "img": "/apps/dota2/images/items/ring_of_health_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_health_lg.png?t=1592658656576",
     "dname": "Ring of Health",
     "qual": "component",
     "cost": 825,
@@ -1520,7 +1520,7 @@
   },
   "void_stone": {
     "id": 57,
-    "img": "/apps/dota2/images/items/void_stone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/void_stone_lg.png?t=1592658656576",
     "dname": "Void Stone",
     "qual": "component",
     "cost": 825,
@@ -1542,7 +1542,7 @@
   },
   "mystic_staff": {
     "id": 58,
-    "img": "/apps/dota2/images/items/mystic_staff_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mystic_staff_lg.png?t=1592658656576",
     "dname": "Mystic Staff",
     "qual": "secret_shop",
     "cost": 2700,
@@ -1564,7 +1564,7 @@
   },
   "energy_booster": {
     "id": 59,
-    "img": "/apps/dota2/images/items/energy_booster_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/energy_booster_lg.png?t=1592658656576",
     "dname": "Energy Booster",
     "qual": "secret_shop",
     "cost": 900,
@@ -1586,7 +1586,7 @@
   },
   "point_booster": {
     "id": 60,
-    "img": "/apps/dota2/images/items/point_booster_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/point_booster_lg.png?t=1592658656576",
     "dname": "Point Booster",
     "qual": "secret_shop",
     "cost": 1200,
@@ -1614,7 +1614,7 @@
   },
   "vitality_booster": {
     "id": 61,
-    "img": "/apps/dota2/images/items/vitality_booster_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/vitality_booster_lg.png?t=1592658656576",
     "dname": "Vitality Booster",
     "qual": "secret_shop",
     "cost": 1100,
@@ -1640,7 +1640,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 63,
-    "img": "/apps/dota2/images/items/power_treads_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/power_treads_lg.png?t=1592658656576",
     "dname": "Power Treads",
     "qual": "common",
     "cost": 1400,
@@ -1678,7 +1678,7 @@
   },
   "recipe_hand_of_midas": {
     "id": 64,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Hand of Midas Recipe",
     "cost": 1850,
     "notes": "",
@@ -1692,10 +1692,10 @@
   },
   "hand_of_midas": {
     "hint": [
-      "Active: Transmute Kills a non-hero target for 160 gold and 1.85x experience.  Cannot be used on Ancient Creeps.Range: %abilitycastrange%"
+      "Active: Transmute Kills a non-hero target for 160 gold and 1.85x experience.  Cannot be used on Ancient Creeps.Range: 600"
     ],
     "id": 65,
-    "img": "/apps/dota2/images/items/hand_of_midas_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/hand_of_midas_lg.png?t=1592658656576",
     "dname": "Hand of Midas",
     "qual": "common",
     "cost": 2300,
@@ -1719,7 +1719,7 @@
   },
   "oblivion_staff": {
     "id": 67,
-    "img": "/apps/dota2/images/items/oblivion_staff_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/oblivion_staff_lg.png?t=1592658656576",
     "dname": "Oblivion Staff",
     "qual": "common",
     "cost": 1550,
@@ -1763,7 +1763,7 @@
   },
   "pers": {
     "id": 69,
-    "img": "/apps/dota2/images/items/pers_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pers_lg.png?t=1592658656576",
     "dname": "Perseverance",
     "qual": "common",
     "cost": 1650,
@@ -1797,7 +1797,7 @@
       "Passive: Damage BlockGives a 100% chance to block 30 damage from incoming attacks on melee heroes, and 20 damage on ranged.Has a 50% chance to block damage from creeps."
     ],
     "id": 71,
-    "img": "/apps/dota2/images/items/poor_mans_shield_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/poor_mans_shield_lg.png?t=1592658656576",
     "dname": "Poor Man's Shield",
     "qual": "common",
     "cost": 0,
@@ -1820,7 +1820,7 @@
   },
   "recipe_bracer": {
     "id": 72,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Bracer Recipe",
     "cost": 210,
     "notes": "",
@@ -1834,7 +1834,7 @@
   },
   "bracer": {
     "id": 73,
-    "img": "/apps/dota2/images/items/bracer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/bracer_lg.png?t=1592658656576",
     "dname": "Bracer",
     "qual": "common",
     "cost": 510,
@@ -1877,7 +1877,7 @@
   },
   "recipe_wraith_band": {
     "id": 74,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Wraith Band Recipe",
     "cost": 210,
     "notes": "",
@@ -1891,7 +1891,7 @@
   },
   "wraith_band": {
     "id": 75,
-    "img": "/apps/dota2/images/items/wraith_band_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/wraith_band_lg.png?t=1592658656576",
     "dname": "Wraith Band",
     "qual": "common",
     "cost": 510,
@@ -1934,7 +1934,7 @@
   },
   "recipe_null_talisman": {
     "id": 76,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Null Talisman Recipe",
     "cost": 210,
     "notes": "",
@@ -1948,7 +1948,7 @@
   },
   "null_talisman": {
     "id": 77,
-    "img": "/apps/dota2/images/items/null_talisman_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/null_talisman_lg.png?t=1592658656576",
     "dname": "Null Talisman",
     "qual": "common",
     "cost": 510,
@@ -1990,7 +1990,7 @@
   },
   "recipe_mekansm": {
     "id": 78,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Mekansm Recipe",
     "cost": 1000,
     "notes": "",
@@ -2008,7 +2008,7 @@
       "Passive: Mekansm AuraGrants 2 health regeneration to allied units in a 1200 radius."
     ],
     "id": 79,
-    "img": "/apps/dota2/images/items/mekansm_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mekansm_lg.png?t=1592658656576",
     "dname": "Mekansm",
     "qual": "rare",
     "cost": 1975,
@@ -2039,7 +2039,7 @@
   },
   "recipe_vladmir": {
     "id": 80,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Vladmir's Offering Recipe",
     "cost": 600,
     "notes": "",
@@ -2056,7 +2056,7 @@
       "Passive: Vladmir's AuraGrants 20% lifesteal, 1.5 mana regeneration, and 3 armor to nearby allies. Radius: 1200"
     ],
     "id": 81,
-    "img": "/apps/dota2/images/items/vladmir_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/vladmir_lg.png?t=1592658656576",
     "dname": "Vladmir's Offering",
     "qual": "rare",
     "cost": 2300,
@@ -2082,7 +2082,7 @@
   },
   "recipe_buckler": {
     "id": 85,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Buckler Recipe",
     "cost": 225,
     "notes": "",
@@ -2099,7 +2099,7 @@
       "Passive: Buckler Aura Grants 2.5 armor to allied player units.Radius: 1200"
     ],
     "id": 86,
-    "img": "/apps/dota2/images/items/buckler_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/buckler_lg.png?t=1592658656576",
     "dname": "Buckler",
     "qual": "rare",
     "cost": 375,
@@ -2116,7 +2116,7 @@
   },
   "recipe_ring_of_basilius": {
     "id": 87,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "cost": 200,
     "notes": "",
     "attrib": [],
@@ -2132,7 +2132,7 @@
       "Passive: Basilius AuraGrants 1.4 mana regeneration to allies.  Radius: 1200"
     ],
     "id": 88,
-    "img": "/apps/dota2/images/items/ring_of_basilius_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_basilius_lg.png?t=1592658656576",
     "dname": "Ring of Basilius",
     "qual": "rare",
     "cost": 425,
@@ -2149,7 +2149,7 @@
   },
   "recipe_holy_locket": {
     "id": 268,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Holy Locket Recipe",
     "cost": 500,
     "notes": "",
@@ -2168,7 +2168,7 @@
       " Passive: Holy BlessingAmplifies heals you provide by 35%."
     ],
     "id": 269,
-    "img": "/apps/dota2/images/items/holy_locket_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/holy_locket_lg.png?t=1592658656576",
     "dname": "Holy Locket",
     "qual": "rare",
     "cost": 2500,
@@ -2212,7 +2212,7 @@
   },
   "recipe_pipe": {
     "id": 89,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Pipe of Insight Recipe",
     "cost": 1200,
     "notes": "",
@@ -2230,7 +2230,7 @@
       "Passive: Insight Aura Gives allied units 2 health regeneration and 10% magic resistance.Radius: 1200"
     ],
     "id": 90,
-    "img": "/apps/dota2/images/items/pipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pipe_lg.png?t=1592658656576",
     "dname": "Pipe of Insight",
     "qual": "rare",
     "cost": 3425,
@@ -2261,7 +2261,7 @@
   },
   "recipe_urn_of_shadows": {
     "id": 91,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Urn of Shadows Recipe",
     "cost": 310,
     "notes": "",
@@ -2275,10 +2275,10 @@
   },
   "urn_of_shadows": {
     "hint": [
-      "Active: Soul Release Provides 30 health regeneration when cast on allies, and deals 25 damage per second when cast on enemies. Lasts 8 seconds.  Gains charges every time an enemy hero dies within 1400 units.  Only the closest Urn to the dying hero will gain a charge.Cast Range: %abilitycastrange%"
+      "Active: Soul Release Provides 30 health regeneration when cast on allies, and deals 25 damage per second when cast on enemies. Lasts 8 seconds.  Gains charges every time an enemy hero dies within 1400 units.  Only the closest Urn to the dying hero will gain a charge.Cast Range: 950"
     ],
     "id": 92,
-    "img": "/apps/dota2/images/items/urn_of_shadows_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/urn_of_shadows_lg.png?t=1592658656576",
     "dname": "Urn of Shadows",
     "qual": "rare",
     "cost": 840,
@@ -2316,7 +2316,7 @@
   },
   "recipe_headdress": {
     "id": 93,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Headdress Recipe",
     "cost": 200,
     "notes": "",
@@ -2333,7 +2333,7 @@
       "Passive: Regeneration AuraGrants 2 health regeneration to allies.Radius: 1200"
     ],
     "id": 94,
-    "img": "/apps/dota2/images/items/headdress_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/headdress_lg.png?t=1592658656576",
     "dname": "Headdress",
     "qual": "rare",
     "cost": 425,
@@ -2350,10 +2350,10 @@
   },
   "sheepstick": {
     "hint": [
-      "Active: HexTurns a target unit into a harmless critter for 3.5 seconds. The target has a base movement speed of 140 and will be silenced, muted, and disarmed.Instantly destroys illusions.Range: %abilitycastrange%"
+      "Active: HexTurns a target unit into a harmless critter for 3.5 seconds. The target has a base movement speed of 140 and will be silenced, muted, and disarmed.Instantly destroys illusions.Range: 800"
     ],
     "id": 96,
-    "img": "/apps/dota2/images/items/sheepstick_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/sheepstick_lg.png?t=1592658656576",
     "dname": "Scythe of Vyse",
     "qual": "rare",
     "cost": 5675,
@@ -2397,7 +2397,7 @@
   },
   "recipe_orchid": {
     "id": 97,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Orchid Malevolence Recipe",
     "cost": 775,
     "notes": "",
@@ -2411,10 +2411,10 @@
   },
   "orchid": {
     "hint": [
-      "Active: Soul BurnSilences the target unit for 5 seconds. At the end of the silence, 30% of the damage received while silenced is inflicted as bonus magical damage.Range: %abilitycastrange%"
+      "Active: Soul BurnSilences the target unit for 5 seconds. At the end of the silence, 30% of the damage received while silenced is inflicted as bonus magical damage.Range: 900"
     ],
     "id": 98,
-    "img": "/apps/dota2/images/items/orchid_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/orchid_lg.png?t=1592658656576",
     "dname": "Orchid Malevolence",
     "qual": "rare",
     "cost": 3875,
@@ -2457,7 +2457,7 @@
   },
   "recipe_bloodthorn": {
     "id": 245,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Bloodthorn Recipe",
     "cost": 1000,
     "notes": "",
@@ -2471,10 +2471,10 @@
   },
   "bloodthorn": {
     "hint": [
-      "Active: Soul Rend Silences a target for 5 seconds. At the end of the silence, an additional 30% of all damage taken during the silence will be dealt to the target as magical damage.All attacks on the silenced target will have True Strike and 100% chance to crit for 130% damage.Range: %abilitycastrange%"
+      "Active: Soul Rend Silences a target for 5 seconds. At the end of the silence, an additional 30% of all damage taken during the silence will be dealt to the target as magical damage.All attacks on the silenced target will have True Strike and 100% chance to crit for 130% damage.Range: 900"
     ],
     "id": 250,
-    "img": "/apps/dota2/images/items/bloodthorn_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/bloodthorn_lg.png?t=1592658656576",
     "dname": "Bloodthorn",
     "qual": "epic",
     "cost": 6875,
@@ -2520,7 +2520,7 @@
       "Passive: Echo Strike Causes melee attacks to attack twice in quick succession. The double attacks apply a 100% movement slow for 0.8 seconds on each strike."
     ],
     "id": 252,
-    "img": "/apps/dota2/images/items/echo_sabre_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/echo_sabre_lg.png?t=1592658656576",
     "dname": "Echo Sabre",
     "qual": "artifact",
     "cost": 2550,
@@ -2569,7 +2569,7 @@
   },
   "recipe_cyclone": {
     "id": 99,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Eul's Scepter Recipe",
     "cost": 650,
     "notes": "",
@@ -2583,10 +2583,10 @@
   },
   "cyclone": {
     "hint": [
-      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can only be cast on enemy units or yourself.Enemy units take 50 magical damage upon landing.Range: %abilitycastrange%Dispel Type: Basic Dispel"
+      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can only be cast on enemy units or yourself.Enemy units take 50 magical damage upon landing.Range: 575Dispel Type: Basic Dispel"
     ],
     "id": 100,
-    "img": "/apps/dota2/images/items/cyclone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/cyclone_lg.png?t=1592658656576",
     "dname": "Eul's Scepter of Divinity",
     "qual": "rare",
     "cost": 2725,
@@ -2624,7 +2624,7 @@
   },
   "recipe_aether_lens": {
     "id": 233,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Aether Lens Recipe",
     "cost": 600,
     "notes": "",
@@ -2641,7 +2641,7 @@
       "Passive: Aethereal Focus Increases targeted spell and item cast range by 250."
     ],
     "id": 232,
-    "img": "/apps/dota2/images/items/aether_lens_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/aether_lens_lg.png?t=1592658656576",
     "dname": "Aether Lens",
     "qual": "rare",
     "cost": 2325,
@@ -2672,7 +2672,7 @@
   },
   "recipe_force_staff": {
     "id": 101,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Force Staff Recipe",
     "cost": 1000,
     "notes": "",
@@ -2686,10 +2686,10 @@
   },
   "force_staff": {
     "hint": [
-      "Active: ForcePushes any target unit 600 units in the direction it is facing.Range: %abilitycastrange%"
+      "Active: ForcePushes any target unit 600 units in the direction it is facing.Range: 550"
     ],
     "id": 102,
-    "img": "/apps/dota2/images/items/force_staff_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/force_staff_lg.png?t=1592658656576",
     "dname": "Force Staff",
     "qual": "rare",
     "cost": 2225,
@@ -2720,7 +2720,7 @@
   },
   "recipe_hurricane_pike": {
     "id": 262,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Hurricane Pike Recipe",
     "cost": 450,
     "notes": "",
@@ -2734,11 +2734,11 @@
   },
   "hurricane_pike": {
     "hint": [
-      "Active: Hurricane Thrust Pushes you and target enemy 450 units away from each other, and for 5 seconds, allows you to make 4 attacks against the target without range restrictions and with +100 attack speed.Works like Force Staff when used on self or allies.Allied Range: %abilitycastrange%Enemy Range: 400",
+      "Active: Hurricane Thrust Pushes you and target enemy 450 units away from each other, and for 5 seconds, allows you to make 4 attacks against the target without range restrictions and with +100 attack speed.Works like Force Staff when used on self or allies.Allied Range: 550Enemy Range: 400",
       "Passive:  Dragon's Reach Increases attack range of ranged heroes by 140."
     ],
     "id": 263,
-    "img": "/apps/dota2/images/items/hurricane_pike_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/hurricane_pike_lg.png?t=1592658656576",
     "dname": "Hurricane Pike",
     "qual": "epic",
     "cost": 4575,
@@ -2781,7 +2781,7 @@
   },
   "recipe_dagon": {
     "id": 103,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Dagon Recipe",
     "cost": 1250,
     "notes": "",
@@ -2795,10 +2795,10 @@
   },
   "dagon": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: %abilitycastrange%Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
     ],
     "id": 104,
-    "img": "/apps/dota2/images/items/dagon_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dagon_lg.png?t=1592658656576",
     "dname": "Dagon",
     "qual": "rare",
     "cost": 2700,
@@ -2835,10 +2835,10 @@
   },
   "dagon_2": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: %abilitycastrange%Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
     ],
     "id": 201,
-    "img": "/apps/dota2/images/items/dagon_2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dagon_2_lg.png?t=1592658656576",
     "dname": "Dagon",
     "qual": "rare",
     "cost": 3950,
@@ -2875,10 +2875,10 @@
   },
   "dagon_3": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: %abilitycastrange%Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
     ],
     "id": 202,
-    "img": "/apps/dota2/images/items/dagon_3_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dagon_3_lg.png?t=1592658656576",
     "dname": "Dagon",
     "qual": "rare",
     "cost": 5200,
@@ -2915,10 +2915,10 @@
   },
   "dagon_4": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: %abilitycastrange%Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
     ],
     "id": 203,
-    "img": "/apps/dota2/images/items/dagon_4_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dagon_4_lg.png?t=1592658656576",
     "dname": "Dagon",
     "qual": "rare",
     "cost": 6450,
@@ -2955,10 +2955,10 @@
   },
   "dagon_5": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit.Damage: 400,500,600,700,800Range: %abilitycastrange%Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
     ],
     "id": 204,
-    "img": "/apps/dota2/images/items/dagon_5_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dagon_5_lg.png?t=1592658656576",
     "dname": "Dagon",
     "qual": "rare",
     "cost": 7700,
@@ -2995,7 +2995,7 @@
   },
   "recipe_necronomicon": {
     "id": 105,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Necronomicon Recipe",
     "cost": 1250,
     "notes": "",
@@ -3012,7 +3012,7 @@
       "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 75,100,125Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 60,90,120Aura Move Speed: 5,7,9Aura Attack Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 106,
-    "img": "/apps/dota2/images/items/necronomicon_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/necronomicon_lg.png?t=1592658656576",
     "dname": "Necronomicon",
     "qual": "rare",
     "cost": 2150,
@@ -3055,7 +3055,7 @@
       "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 75,100,125Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 60,90,120Aura Move Speed: 5,7,9Aura Attack Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 193,
-    "img": "/apps/dota2/images/items/necronomicon_2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/necronomicon_2_lg.png?t=1592658656576",
     "dname": "Necronomicon",
     "qual": "rare",
     "cost": 3400,
@@ -3097,7 +3097,7 @@
       "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 75,100,125Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 60,90,120Aura Move Speed: 5,7,9Aura Attack Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 194,
-    "img": "/apps/dota2/images/items/necronomicon_3_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/necronomicon_3_lg.png?t=1592658656576",
     "dname": "Necronomicon",
     "qual": "rare",
     "cost": 4650,
@@ -3139,7 +3139,7 @@
       "Passive: Ability UpgradeUpgrades the ultimate, and some abilities, of all heroes."
     ],
     "id": 108,
-    "img": "/apps/dota2/images/items/ultimate_scepter_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ultimate_scepter_lg.png?t=1592658656576",
     "dname": "Aghanim's Scepter",
     "qual": "rare",
     "cost": 4200,
@@ -3178,7 +3178,7 @@
   },
   "recipe_ultimate_scepter_2": {
     "id": 270,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Aghanim's Blessing Recipe",
     "cost": 1800,
     "notes": "",
@@ -3195,7 +3195,7 @@
       "Passive: Ability UpgradeUpgrades the ultimate, and some abilities, of all heroes."
     ],
     "id": 271,
-    "img": "/apps/dota2/images/items/ultimate_scepter_2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ultimate_scepter_2_lg.png?t=1592658656576",
     "dname": "Aghanim's Blessing",
     "qual": "rare",
     "cost": 6000,
@@ -3212,7 +3212,7 @@
   },
   "recipe_refresher": {
     "id": 109,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Refresher Orb Recipe",
     "cost": 1700,
     "notes": "",
@@ -3229,7 +3229,7 @@
       "Active: Reset CooldownsResets the cooldowns of all your items and abilities."
     ],
     "id": 110,
-    "img": "/apps/dota2/images/items/refresher_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/refresher_lg.png?t=1592658656576",
     "dname": "Refresher Orb",
     "qual": "rare",
     "cost": 5000,
@@ -3260,7 +3260,7 @@
   },
   "recipe_assault": {
     "id": 111,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Assault Cuirass Recipe",
     "cost": 1300,
     "notes": "",
@@ -3277,7 +3277,7 @@
       "Passive: Assault Aura Grants 25 attack speed and 5 armor to nearby allied units and structures, and decreases nearby enemy unit and structure armor by -5.Radius: 1200"
     ],
     "id": 112,
-    "img": "/apps/dota2/images/items/assault_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/assault_lg.png?t=1592658656576",
     "dname": "Assault Cuirass",
     "qual": "epic",
     "cost": 5075,
@@ -3315,7 +3315,7 @@
   },
   "recipe_heart": {
     "id": 113,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Heart of Tarrasque Recipe",
     "cost": 400,
     "notes": "",
@@ -3332,7 +3332,7 @@
       "Passive: Health RegenerationRestores 5% of max health per second. If damage is taken from an enemy hero or Roshan, this ability is disabled for 5 seconds for melee heroes, or 7 seconds for ranged heroes."
     ],
     "id": 114,
-    "img": "/apps/dota2/images/items/heart_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/heart_lg.png?t=1592658656576",
     "dname": "Heart of Tarrasque",
     "qual": "epic",
     "cost": 5150,
@@ -3375,7 +3375,7 @@
   },
   "recipe_black_king_bar": {
     "id": 115,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Black King Bar Recipe",
     "cost": 1450,
     "notes": "",
@@ -3392,7 +3392,7 @@
       "Active: Avatar Grants Spell Immunity.  Duration decreases with each use. Duration: 10,9,8,7,6,5 Dispel Type: Basic Dispel"
     ],
     "id": 116,
-    "img": "/apps/dota2/images/items/black_king_bar_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/black_king_bar_lg.png?t=1592658656576",
     "dname": "Black King Bar",
     "qual": "epic",
     "cost": 4050,
@@ -3426,7 +3426,7 @@
       "Passive: Reincarnation Brings you to life with full health and mana 5 seconds after you die, at the location where you died. Reincarnation must be used within 5 minutes or Aegis of the Immortal disappears. If it expires, it will heal you over 5 seconds (dispels on damage)."
     ],
     "id": 117,
-    "img": "/apps/dota2/images/items/aegis_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/aegis_lg.png?t=1592658656576",
     "dname": "Aegis of the Immortal",
     "qual": "artifact",
     "cost": 0,
@@ -3441,7 +3441,7 @@
   },
   "recipe_shivas_guard": {
     "id": 118,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Shiva's Guard Recipe",
     "cost": 650,
     "notes": "",
@@ -3459,7 +3459,7 @@
       "Passive: Freezing Aura Reduces the attack speed of all enemies by -45. Radius: 1200"
     ],
     "id": 119,
-    "img": "/apps/dota2/images/items/shivas_guard_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/shivas_guard_lg.png?t=1592658656576",
     "dname": "Shiva's Guard",
     "qual": "epic",
     "cost": 4750,
@@ -3494,7 +3494,7 @@
       " Passive: Mana BatteryEach charge provides 0.2 MP regen and 0.35% Spell Amp. Nearby kills provide 1 charges. Dying causes you to lose 3 charges. Starts with 14 charges. Provides +100% Mana Regen Amplification."
     ],
     "id": 121,
-    "img": "/apps/dota2/images/items/bloodstone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/bloodstone_lg.png?t=1592658656576",
     "dname": "Bloodstone",
     "qual": "epic",
     "cost": 5250,
@@ -3541,7 +3541,7 @@
   },
   "recipe_sphere": {
     "id": 122,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Linken's Sphere Recipe",
     "cost": 1200,
     "notes": "",
@@ -3556,10 +3556,10 @@
   "sphere": {
     "hint": [
       "Passive: SpellblockBlocks most targeted spells once every 12 seconds.",
-      "Active: Transfer SpellblockTemporarily removes Spellblock from the item's owner and transfers it to an allied unit for 12 seconds.Range: %abilitycastrange%"
+      "Active: Transfer SpellblockTemporarily removes Spellblock from the item's owner and transfers it to an allied unit for 12 seconds.Range: 700"
     ],
     "id": 123,
-    "img": "/apps/dota2/images/items/sphere_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/sphere_lg.png?t=1592658656576",
     "dname": "Linken's Sphere",
     "qual": "epic",
     "cost": 5000,
@@ -3596,10 +3596,10 @@
   },
   "lotus_orb": {
     "hint": [
-      "Active: Echo ShellApplies a shield to the target unit for 6 seconds which re-casts most targeted spells back to their caster.The shielded unit will still take damage from the spell. Range: %abilitycastrange%Dispel Type: Basic Dispel"
+      "Active: Echo ShellApplies a shield to the target unit for 6 seconds which re-casts most targeted spells back to their caster.The shielded unit will still take damage from the spell. Range: 900Dispel Type: Basic Dispel"
     ],
     "id": 226,
-    "img": "/apps/dota2/images/items/lotus_orb_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/lotus_orb_lg.png?t=1592658656576",
     "dname": "Lotus Orb",
     "qual": "epic",
     "cost": 3950,
@@ -3646,7 +3646,7 @@
       "Active: Meteor Hammer CHANNELED - After a successful channel, summons a meteor that strikes a 315 AoE, stunning enemies for 2 seconds and dealing impact damage. Continues to deal damage over time to enemies units and buildings for 6 seconds.Building Impact Damage: 75 Building Over Time Damage: 50 Non-Building Impact Damage: 150 Non-Building Over Time Damage: 90 Channel Duration: 2.5 seconds.Landing Time: 0.5 seconds."
     ],
     "id": 223,
-    "img": "/apps/dota2/images/items/meteor_hammer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/meteor_hammer_lg.png?t=1592658656576",
     "dname": "Meteor Hammer",
     "qual": "epic",
     "cost": 2450,
@@ -3694,7 +3694,7 @@
       "Active: Nullify Dispels the target and applies a debuff for 5 seconds. Continuously dispels the target. Anytime the target is attacked, it will be slowed by 80% for 0.5 seconds.Dispel Type: Basic Dispel"
     ],
     "id": 225,
-    "img": "/apps/dota2/images/items/nullifier_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/nullifier_lg.png?t=1592658656576",
     "dname": "Nullifier",
     "qual": "epic",
     "cost": 4725,
@@ -3731,7 +3731,7 @@
   },
   "recipe_aeon_disk": {
     "id": 255,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Aeon Disk Recipe",
     "cost": 1100,
     "notes": "",
@@ -3748,7 +3748,7 @@
       "Passive: Combo Breaker When you take damage and your health falls below 70%, a strong dispel is applied and you gain a 2.5 second buff that provides +75% Status Resistance and causes all damage you deal and are dealt to be reduced to zero. Only triggers on player based damage."
     ],
     "id": 256,
-    "img": "/apps/dota2/images/items/aeon_disk_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/aeon_disk_lg.png?t=1592658656576",
     "dname": "Aeon Disk",
     "qual": "epic",
     "cost": 3100,
@@ -3779,7 +3779,7 @@
   },
   "recipe_kaya": {
     "id": 258,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Kaya Recipe",
     "cost": 600,
     "notes": "",
@@ -3793,7 +3793,7 @@
   },
   "kaya": {
     "id": 259,
-    "img": "/apps/dota2/images/items/kaya_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/kaya_lg.png?t=1592658656576",
     "dname": "Kaya",
     "qual": "epic",
     "cost": 2050,
@@ -3831,7 +3831,7 @@
       "Combines Sange, Yasha and Kaya together."
     ],
     "id": 369,
-    "img": "/apps/dota2/images/items/trident_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/trident_lg.png?t=1592658656576",
     "dname": "Trident",
     "cost": 0,
     "notes": "",
@@ -3902,7 +3902,7 @@
   },
   "combo_breaker": {
     "id": 276,
-    "img": "/apps/dota2/images/items/combo_breaker_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/combo_breaker_lg.png?t=1592658656576",
     "cost": null,
     "notes": "",
     "attrib": [],
@@ -3918,7 +3918,7 @@
       "Use: Reset CooldownsResets the cooldowns of all your items and abilities."
     ],
     "id": 260,
-    "img": "/apps/dota2/images/items/refresher_shard_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/refresher_shard_lg.png?t=1592658656576",
     "dname": "Refresher Shard",
     "qual": "consumable",
     "cost": 1000,
@@ -3933,7 +3933,7 @@
   },
   "recipe_spirit_vessel": {
     "id": 266,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Spirit Vessel Recipe",
     "cost": 1000,
     "notes": "",
@@ -3947,11 +3947,11 @@
   },
   "spirit_vessel": {
     "hint": [
-      "Active: Soul Release When used against enemies, it reduces health by 4% of current health per second, and reduces HP regeneration and healing by 35%. Deals 25 damage per second. When used on allies, it provides 30 health regeneration per second. Lasts 8 seconds.  Gains charges every time an enemy hero dies within 1400 units.  Only the closest Spirit Vessel to the dying hero will gain a charge.Cast Range: %abilitycastrange% ",
+      "Active: Soul Release When used against enemies, it reduces health by 4% of current health per second, and reduces HP regeneration and healing by 35%. Deals 25 damage per second. When used on allies, it provides 30 health regeneration per second. Lasts 8 seconds.  Gains charges every time an enemy hero dies within 1400 units.  Only the closest Spirit Vessel to the dying hero will gain a charge.Cast Range: 950 ",
       "Passive: Spirit Vessel Degen Aura Reduces all heals, regeneration and lifesteal of nearby enemy units by 20% Radius: 1200"
     ],
     "id": 267,
-    "img": "/apps/dota2/images/items/spirit_vessel_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/spirit_vessel_lg.png?t=1592658656576",
     "dname": "Spirit Vessel",
     "qual": "rare",
     "cost": 2940,
@@ -3997,7 +3997,7 @@
       "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 125,
-    "img": "/apps/dota2/images/items/vanguard_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/vanguard_lg.png?t=1592658656576",
     "dname": "Vanguard",
     "qual": "epic",
     "cost": 1925,
@@ -4028,7 +4028,7 @@
   },
   "recipe_crimson_guard": {
     "id": 243,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Crimson Guard Recipe",
     "cost": 950,
     "notes": "",
@@ -4046,7 +4046,7 @@
       "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 242,
-    "img": "/apps/dota2/images/items/crimson_guard_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/crimson_guard_lg.png?t=1592658656576",
     "dname": "Crimson Guard",
     "qual": "epic",
     "cost": 3800,
@@ -4092,7 +4092,7 @@
       "Active: Damage ReturnFor 4.5 seconds, duplicates any damage taken back to the unit that dealt the damage."
     ],
     "id": 127,
-    "img": "/apps/dota2/images/items/blade_mail_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/blade_mail_lg.png?t=1592658656576",
     "dname": "Blade Mail",
     "qual": "epic",
     "cost": 2000,
@@ -4130,7 +4130,7 @@
   },
   "soul_booster": {
     "id": 129,
-    "img": "/apps/dota2/images/items/soul_booster_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/soul_booster_lg.png?t=1592658656576",
     "dname": "Soul Booster",
     "qual": "epic",
     "cost": 3200,
@@ -4162,7 +4162,7 @@
   },
   "recipe_hood_of_defiance": {
     "id": 130,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "cost": 200,
     "notes": "",
     "attrib": [],
@@ -4178,7 +4178,7 @@
       "Active: Barrier Creates a spell shield that absorbs up to 325 magical damage.  Lasts 12 seconds."
     ],
     "id": 131,
-    "img": "/apps/dota2/images/items/hood_of_defiance_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/hood_of_defiance_lg.png?t=1592658656576",
     "dname": "Hood of Defiance",
     "qual": "epic",
     "cost": 1800,
@@ -4215,7 +4215,7 @@
       "  Passive: True Strike Your attacks cannot miss."
     ],
     "id": 133,
-    "img": "/apps/dota2/images/items/rapier_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/rapier_lg.png?t=1592658656576",
     "dname": "Divine Rapier",
     "qual": "epic",
     "cost": 6000,
@@ -4243,7 +4243,7 @@
       "Passive: PierceGrants each attack a 75% chance to pierce through evasion and deal 100 bonus magical damage."
     ],
     "id": 135,
-    "img": "/apps/dota2/images/items/monkey_king_bar_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/monkey_king_bar_lg.png?t=1592658656576",
     "dname": "Monkey King Bar",
     "qual": "epic",
     "cost": 4175,
@@ -4275,7 +4275,7 @@
   },
   "recipe_radiance": {
     "id": 136,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Radiance Recipe",
     "cost": 1350,
     "notes": "",
@@ -4292,7 +4292,7 @@
       "Toggle: Burn When active, scorches enemies for 60 magical damage per second, and causes them to miss 17% of their attacks. Illusions deal 35 magical damage per second.Radius: 700"
     ],
     "id": 137,
-    "img": "/apps/dota2/images/items/radiance_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/radiance_lg.png?t=1592658656576",
     "dname": "Radiance",
     "qual": "epic",
     "cost": 5150,
@@ -4316,7 +4316,7 @@
   },
   "butterfly": {
     "id": 139,
-    "img": "/apps/dota2/images/items/butterfly_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/butterfly_lg.png?t=1592658656576",
     "dname": "Butterfly",
     "qual": "epic",
     "cost": 5275,
@@ -4360,7 +4360,7 @@
   },
   "recipe_greater_crit": {
     "id": 140,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Daedalus Recipe",
     "cost": 1000,
     "notes": "",
@@ -4377,7 +4377,7 @@
       "Passive: Critical StrikeGrants each attack a 30% chance to deal 225% damage."
     ],
     "id": 141,
-    "img": "/apps/dota2/images/items/greater_crit_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/greater_crit_lg.png?t=1592658656576",
     "dname": "Daedalus",
     "qual": "epic",
     "cost": 5350,
@@ -4402,7 +4402,7 @@
   },
   "recipe_basher": {
     "id": 142,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Skull Basher Recipe",
     "cost": 900,
     "notes": "",
@@ -4419,7 +4419,7 @@
       "Passive: Bash Grants melee heroes a 25% chance on hit to stun the target for 1.5 seconds and deal 100 bonus physical damage.  Bash chance for ranged heroes is 10%."
     ],
     "id": 143,
-    "img": "/apps/dota2/images/items/basher_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/basher_lg.png?t=1592658656576",
     "dname": "Skull Basher",
     "qual": "epic",
     "cost": 2950,
@@ -4450,12 +4450,12 @@
   },
   "bfury": {
     "hint": [
-      "Active: Chop Tree Destroy a target tree.Cast Range: %abilitycastrange%",
+      "Active: Chop Tree Destroy a target tree.Cast Range: 350",
       "Passive: Quell Increases attack damage against non-hero units by 18 for melee heroes, and 5 for ranged. ",
       "Passive: Cleave Deals 70% of attack damage as physical damage in a cone up to 650 around the target. Deals 50% against creeps. (Melee Only)"
     ],
     "id": 145,
-    "img": "/apps/dota2/images/items/bfury_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/bfury_lg.png?t=1592658656576",
     "dname": "Battle Fury",
     "qual": "epic",
     "cost": 4400,
@@ -4494,7 +4494,7 @@
   },
   "recipe_manta": {
     "id": 146,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Manta Style Recipe",
     "cost": 500,
     "notes": "",
@@ -4511,7 +4511,7 @@
       "Active: Mirror ImageCreates 2 images of your hero that last 20 seconds. Melee images deal 33% damage and take 350% damage, while Ranged images deal 28% and take 400% damage. Cooldown increased by 15 seconds on ranged heroes.Dispel Type: Basic Dispel"
     ],
     "id": 147,
-    "img": "/apps/dota2/images/items/manta_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/manta_lg.png?t=1592658656576",
     "dname": "Manta Style",
     "qual": "epic",
     "cost": 4700,
@@ -4560,7 +4560,7 @@
   },
   "recipe_lesser_crit": {
     "id": 148,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Crystalys Recipe",
     "cost": 700,
     "notes": "",
@@ -4577,7 +4577,7 @@
       "Passive: Critical StrikeGrants each attack a 30% chance to deal 160% damage."
     ],
     "id": 149,
-    "img": "/apps/dota2/images/items/lesser_crit_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/lesser_crit_lg.png?t=1592658656576",
     "dname": "Crystalys",
     "qual": "epic",
     "cost": 2150,
@@ -4605,7 +4605,7 @@
       "Passive: Dragon's Reach Increases attack range of ranged heroes by 140."
     ],
     "id": 236,
-    "img": "/apps/dota2/images/items/dragon_lance_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dragon_lance_lg.png?t=1592658656576",
     "dname": "Dragon Lance",
     "qual": "artifact",
     "cost": 1900,
@@ -4637,7 +4637,7 @@
   },
   "recipe_armlet": {
     "id": 150,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Armlet of Mordiggian Recipe",
     "cost": 650,
     "notes": "",
@@ -4654,7 +4654,7 @@
       "Toggle: Unholy StrengthWhen active, Unholy Strength grants +31 damage, +25 strength and +4 armor, but drains 54 health per second. You cannot die from the health drain when Unholy Strength is activated, nor from the strength loss when Unholy Strength is deactivated."
     ],
     "id": 151,
-    "img": "/apps/dota2/images/items/armlet_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/armlet_lg.png?t=1592658656576",
     "dname": "Armlet of Mordiggian",
     "qual": "epic",
     "cost": 2475,
@@ -4701,7 +4701,7 @@
       "Active: Shadow WalkMakes you invisible for 14 seconds, or until you attack or cast a spell.  While Shadow Walk is active, you move 20% faster and can move through units.  If attacking to end the invisibility, you gain 175 bonus physical damage on that attack."
     ],
     "id": 152,
-    "img": "/apps/dota2/images/items/invis_sword_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/invis_sword_lg.png?t=1592658656576",
     "dname": "Shadow Blade",
     "qual": "epic",
     "cost": 2800,
@@ -4732,7 +4732,7 @@
   },
   "recipe_silver_edge": {
     "id": 248,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Silver Edge Recipe",
     "cost": 600,
     "notes": "",
@@ -4749,7 +4749,7 @@
       "Active: Shadow WalkMakes you invisible for 14 seconds, or until you attack or cast a spell.  While invisible, you move 25% faster and can move through units.  Attacking to end the invisibility will deal 175 bonus physical damage to the target, and disable their passive abilities for 4 seconds."
     ],
     "id": 249,
-    "img": "/apps/dota2/images/items/silver_edge_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/silver_edge_lg.png?t=1592658656576",
     "dname": "Silver Edge",
     "qual": "epic",
     "cost": 5550,
@@ -4786,7 +4786,7 @@
   },
   "sange_and_yasha": {
     "id": 154,
-    "img": "/apps/dota2/images/items/sange_and_yasha_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/sange_and_yasha_lg.png?t=1592658656576",
     "dname": "Sange and Yasha",
     "qual": "artifact",
     "cost": 4100,
@@ -4839,7 +4839,7 @@
   },
   "kaya_and_sange": {
     "id": 273,
-    "img": "/apps/dota2/images/items/kaya_and_sange_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/kaya_and_sange_lg.png?t=1592658656576",
     "dname": "Kaya and Sange",
     "qual": "artifact",
     "cost": 4100,
@@ -4890,7 +4890,7 @@
   },
   "yasha_and_kaya": {
     "id": 277,
-    "img": "/apps/dota2/images/items/yasha_and_kaya_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/yasha_and_kaya_lg.png?t=1592658656576",
     "dname": "Yasha and Kaya",
     "qual": "artifact",
     "cost": 4100,
@@ -4947,7 +4947,7 @@
       "Passive: LifestealHeals the attacker for 25% of attack damage dealt."
     ],
     "id": 156,
-    "img": "/apps/dota2/images/items/satanic_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/satanic_lg.png?t=1592658656576",
     "dname": "Satanic",
     "qual": "artifact",
     "cost": 5300,
@@ -4984,7 +4984,7 @@
   },
   "recipe_mjollnir": {
     "id": 157,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Mjollnir Recipe",
     "cost": 900,
     "notes": "",
@@ -4998,11 +4998,11 @@
   },
   "mjollnir": {
     "hint": [
-      "Active: Static ChargePlaces a charged shield on a target unit for 15 seconds which has a 20% chance to release a 200 magical damage shocking bolt at a nearby attacker and 4 additional enemies.Range: %abilitycastrange%",
+      "Active: Static ChargePlaces a charged shield on a target unit for 15 seconds which has a 20% chance to release a 200 magical damage shocking bolt at a nearby attacker and 4 additional enemies.Range: 800",
       "Passive: Chain LightningGrants a 25% chance on attack to release a bolt of electricity that leaps between 12 targets within a 650 radius, dealing 170 magical damage to each. Lightning proc pierces evasion."
     ],
     "id": 158,
-    "img": "/apps/dota2/images/items/mjollnir_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mjollnir_lg.png?t=1592658656576",
     "dname": "Mjollnir",
     "qual": "artifact",
     "cost": 5600,
@@ -5036,7 +5036,7 @@
       "Passive: Cold Attack Attacks lower enemy movement and attack speed and reduces heals, health regeneration and lifesteal by 35% for 3 seconds. Slows enemy ranged units by -45% movement speed and by -45 attack speed. Slows enemy melee units by -20% movement speed and by -20 attack speed. "
     ],
     "id": 160,
-    "img": "/apps/dota2/images/items/skadi_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/skadi_lg.png?t=1592658656576",
     "dname": "Eye of Skadi",
     "qual": "artifact",
     "cost": 5500,
@@ -5074,7 +5074,7 @@
   },
   "recipe_sange": {
     "id": 161,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Sange Recipe",
     "cost": 600,
     "notes": "",
@@ -5088,7 +5088,7 @@
   },
   "sange": {
     "id": 162,
-    "img": "/apps/dota2/images/items/sange_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/sange_lg.png?t=1592658656576",
     "dname": "Sange",
     "qual": "artifact",
     "cost": 2050,
@@ -5123,7 +5123,7 @@
   },
   "recipe_helm_of_the_dominator": {
     "id": 163,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Helm of the Dominator Recipe",
     "cost": 300,
     "notes": "",
@@ -5137,11 +5137,11 @@
   },
   "helm_of_the_dominator": {
     "hint": [
-      "Active: DominateTakes control of one neutral, non-ancient target unit and sets its movement speed to 425 and max health to a minimum of 1500.Dominated units with a max health of greater than 1500 retain their original max health.  Dominated unit's bounty is set to 200 gold.Range: %abilitycastrange%",
+      "Active: DominateTakes control of one neutral, non-ancient target unit and sets its movement speed to 425 and max health to a minimum of 1500.Dominated units with a max health of greater than 1500 retain their original max health.  Dominated unit's bounty is set to 200 gold.Range: 700",
       "Passive: Dominator Aura Increases nearby allied hero and player units base damage by 20%  and health regen by 4.25. Has a 50%  bigger effect on player units.Radius: 1200"
     ],
     "id": 164,
-    "img": "/apps/dota2/images/items/helm_of_the_dominator_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/helm_of_the_dominator_lg.png?t=1592658656576",
     "dname": "Helm of the Dominator",
     "qual": "artifact",
     "cost": 2175,
@@ -5170,7 +5170,7 @@
       "Passive: Chain LightningGrants a 25% chance on attack to release a bolt of electricity that leaps between 4 targets within a 650 radius, dealing 140 magical damage to each. Lightning proc pierces evasion."
     ],
     "id": 166,
-    "img": "/apps/dota2/images/items/maelstrom_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/maelstrom_lg.png?t=1592658656576",
     "dname": "Maelstrom",
     "qual": "artifact",
     "cost": 2700,
@@ -5198,7 +5198,7 @@
       "Passive: Corruption Your attacks reduce the target's armor by -6 for 7 seconds."
     ],
     "id": 168,
-    "img": "/apps/dota2/images/items/desolator_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/desolator_lg.png?t=1592658656576",
     "dname": "Desolator",
     "qual": "artifact",
     "cost": 3500,
@@ -5224,7 +5224,7 @@
   },
   "recipe_yasha": {
     "id": 169,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Yasha Recipe",
     "cost": 600,
     "notes": "",
@@ -5238,7 +5238,7 @@
   },
   "yasha": {
     "id": 170,
-    "img": "/apps/dota2/images/items/yasha_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/yasha_lg.png?t=1592658656576",
     "dname": "Yasha",
     "qual": "artifact",
     "cost": 2050,
@@ -5279,7 +5279,7 @@
       "Passive: LifestealHeals the attacker for 20% of attack damage dealt."
     ],
     "id": 172,
-    "img": "/apps/dota2/images/items/mask_of_madness_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mask_of_madness_lg.png?t=1592658656576",
     "dname": "Mask of Madness",
     "qual": "artifact",
     "cost": 1775,
@@ -5310,7 +5310,7 @@
   },
   "recipe_diffusal_blade": {
     "id": 173,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Diffusal Blade Recipe",
     "cost": 700,
     "notes": "",
@@ -5324,11 +5324,11 @@
   },
   "diffusal_blade": {
     "hint": [
-      "Active: Inhibit Targets an enemy, slowing it for 4 seconds.Range: %abilitycastrange%",
+      "Active: Inhibit Targets an enemy, slowing it for 4 seconds.Range: 600",
       "Passive: ManabreakEach attack burns 40 mana from the target, and deals 0.8 physical damage per burned mana. Burns 16 mana per attack from melee illusions and 8 mana per attack from ranged illusions."
     ],
     "id": 174,
-    "img": "/apps/dota2/images/items/diffusal_blade_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/diffusal_blade_lg.png?t=1592658656576",
     "dname": "Diffusal Blade",
     "qual": "artifact",
     "cost": 3150,
@@ -5360,10 +5360,10 @@
   },
   "ethereal_blade": {
     "hint": [
-      "Active: Ether BlastConverts the target unit to ethereal form, rendering them immune to physical damage, but unable to attack and -40% more vulnerable to magic damage.  Lasts for 4 seconds on allies and 4 seconds on enemies.  Enemy targets are also slowed by -80%, and take 1.5x your primary attribute + 125 as magical damage.Range: %abilitycastrange%"
+      "Active: Ether BlastConverts the target unit to ethereal form, rendering them immune to physical damage, but unable to attack and -40% more vulnerable to magic damage.  Lasts for 4 seconds on allies and 4 seconds on enemies.  Enemy targets are also slowed by -80%, and take 1.5x your primary attribute + 125 as magical damage.Range: 800"
     ],
     "id": 176,
-    "img": "/apps/dota2/images/items/ethereal_blade_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ethereal_blade_lg.png?t=1592658656576",
     "dname": "Ethereal Blade",
     "qual": "epic",
     "cost": 4500,
@@ -5400,7 +5400,7 @@
   },
   "recipe_soul_ring": {
     "id": 177,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Soul Ring Recipe",
     "cost": 300,
     "notes": "",
@@ -5417,7 +5417,7 @@
       "Active: Sacrifice Consume 170 health to temporarily gain 150 mana.  Lasts 10 seconds.If the mana gained cannot fit in your mana pool, it creates a buffer of mana that will be used before your mana pool."
     ],
     "id": 178,
-    "img": "/apps/dota2/images/items/soul_ring_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/soul_ring_lg.png?t=1592658656576",
     "dname": "Soul Ring",
     "qual": "common",
     "cost": 815,
@@ -5453,7 +5453,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 180,
-    "img": "/apps/dota2/images/items/arcane_boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/arcane_boots_lg.png?t=1592658656576",
     "dname": "Arcane Boots",
     "qual": "rare",
     "cost": 1400,
@@ -5488,7 +5488,7 @@
       "Passive: Spell Lifesteal25% of spell damage dealt to enemy heroes is returned to the caster as health, regardless of spell damage type.  Lifesteal reduced to 5% against creeps."
     ],
     "id": 235,
-    "img": "/apps/dota2/images/items/octarine_core_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/octarine_core_lg.png?t=1592658656576",
     "dname": "Octarine Core",
     "qual": "rare",
     "cost": 5900,
@@ -5528,7 +5528,7 @@
       "Passive: Poison AttackPoisons the target, dealing 2 magical damage per second and slowing movement by -15% if the equipped hero is melee, or by -4% if they are ranged. Lasts for 2 seconds."
     ],
     "id": 181,
-    "img": "/apps/dota2/images/items/orb_of_venom_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/orb_of_venom_lg.png?t=1592658656576",
     "dname": "Orb of Venom",
     "qual": "component",
     "cost": 300,
@@ -5546,7 +5546,7 @@
       "Passive: Lesser Corruption Your attacks reduce the target's armor by -2 for 8 seconds."
     ],
     "id": 240,
-    "img": "/apps/dota2/images/items/blight_stone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/blight_stone_lg.png?t=1592658656576",
     "dname": "Blight Stone",
     "qual": "component",
     "cost": 300,
@@ -5561,7 +5561,7 @@
   },
   "recipe_ancient_janggo": {
     "id": 184,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Drum of Endurance Recipe",
     "cost": 800,
     "notes": "",
@@ -5580,7 +5580,7 @@
       "Passive: Speed Aura Increases nearby allies' attack speed by 20.Radius: 1200"
     ],
     "id": 185,
-    "img": "/apps/dota2/images/items/ancient_janggo_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ancient_janggo_lg.png?t=1592658656576",
     "dname": "Drum of Endurance",
     "qual": "rare",
     "cost": 1950,
@@ -5612,10 +5612,10 @@
   },
   "medallion_of_courage": {
     "hint": [
-      "Active: Valor If cast on an ally, grants them the 5 armor, and removing it from the caster. If cast on an enemy, reduces 5 armor on both the enemy and the caster. Cannot target spell immune enemies.Range: %abilitycastrange%"
+      "Active: Valor If cast on an ally, grants them the 5 armor, and removing it from the caster. If cast on an enemy, reduces 5 armor on both the enemy and the caster. Cannot target spell immune enemies.Range: 1000"
     ],
     "id": 187,
-    "img": "/apps/dota2/images/items/medallion_of_courage_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/medallion_of_courage_lg.png?t=1592658656576",
     "dname": "Medallion of Courage",
     "qual": "rare",
     "cost": 1075,
@@ -5647,7 +5647,7 @@
   },
   "recipe_solar_crest": {
     "id": 227,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "cost": 400,
     "notes": "",
     "attrib": [],
@@ -5660,10 +5660,10 @@
   },
   "solar_crest": {
     "hint": [
-      "Active: ShineWhen cast on an ally, grants them 8 armor, 80 attack speed, and 10% movement speed. When cast on an enemy, removes 8 armor, 80 attack speed, and 10% movement speed.Removes the armor from the caster when used.  Cannot target spell immune enemies.Range: %abilitycastrange%"
+      "Active: ShineWhen cast on an ally, grants them 8 armor, 80 attack speed, and 10% movement speed. When cast on an enemy, removes 8 armor, 80 attack speed, and 10% movement speed.Removes the armor from the caster when used.  Cannot target spell immune enemies.Range: 1000"
     ],
     "id": 229,
-    "img": "/apps/dota2/images/items/solar_crest_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/solar_crest_lg.png?t=1592658656576",
     "dname": "Solar Crest",
     "qual": "rare",
     "cost": 3875,
@@ -5710,7 +5710,7 @@
       "Use: Disguise Turns the caster and all allied player-controlled units in a 1200 radius invisible, and grants 15% bonus movement speed for 35 seconds. Attacking, or moving within 1025 range of an enemy hero or tower, will break the invisibility. Disguise grants invisibility that is immune to True Sight."
     ],
     "id": 188,
-    "img": "/apps/dota2/images/items/smoke_of_deceit_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/smoke_of_deceit_lg.png?t=1592658656576",
     "dname": "Smoke of Deceit",
     "qual": "consumable",
     "cost": 80,
@@ -5725,10 +5725,10 @@
   },
   "tome_of_knowledge": {
     "hint": [
-      "Use: EnlightenGrants you 700 experience plus 135 per tome consumed by your team after the first two.Tomes Used By Team: %customval_team_tomes_used%"
+      "Use: EnlightenGrants you 700 experience plus 135 per tome consumed by your team after the first two."
     ],
     "id": 257,
-    "img": "/apps/dota2/images/items/tome_of_knowledge_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tome_of_knowledge_lg.png?t=1592658656576",
     "dname": "Tome of Knowledge",
     "qual": "consumable",
     "cost": 150,
@@ -5743,7 +5743,7 @@
   },
   "recipe_veil_of_discord": {
     "id": 189,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Veil of Discord Recipe",
     "cost": 1150,
     "notes": "",
@@ -5757,12 +5757,12 @@
   },
   "veil_of_discord": {
     "hint": [
-      "Active: Magic Weakness Cast a 600 radius blast that causes enemies to take 20% increased damage from spells.Range: %abilitycastrange%Duration: 16 seconds. ",
+      "Active: Magic Weakness Cast a 600 radius blast that causes enemies to take 20% increased damage from spells.Range: 1000Duration: 16 seconds. ",
       "",
       " Passive: Basilius AuraGrants 1.5 mana regeneration to allies.  Radius: 1200"
     ],
     "id": 190,
-    "img": "/apps/dota2/images/items/veil_of_discord_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/veil_of_discord_lg.png?t=1592658656576",
     "dname": "Veil of Discord",
     "qual": "rare",
     "cost": 2025,
@@ -5787,7 +5787,7 @@
   },
   "recipe_guardian_greaves": {
     "id": 230,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Guardian Greaves Recipe",
     "cost": 1600,
     "notes": "",
@@ -5806,7 +5806,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 231,
-    "img": "/apps/dota2/images/items/guardian_greaves_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/guardian_greaves_lg.png?t=1592658656576",
     "dname": "Guardian Greaves",
     "qual": "rare",
     "cost": 4975,
@@ -5849,7 +5849,7 @@
   },
   "recipe_rod_of_atos": {
     "id": 205,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Rod of Atos Recipe",
     "cost": 850,
     "notes": "",
@@ -5863,10 +5863,10 @@
   },
   "rod_of_atos": {
     "hint": [
-      "Active: CrippleRoots the target for 2 seconds.Range: %abilitycastrange%"
+      "Active: CrippleRoots the target for 2 seconds.Range: 1100"
     ],
     "id": 206,
-    "img": "/apps/dota2/images/items/rod_of_atos_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/rod_of_atos_lg.png?t=1592658656576",
     "dname": "Rod of Atos",
     "qual": "rare",
     "cost": 2750,
@@ -5918,10 +5918,10 @@
   },
   "iron_talon": {
     "hint": [
-      "Active: ChopTargets a non-player enemy unit to remove 50% of its current HP.If cast on a tree, instantly destroys it.Unit Range: %abilitycastrange%Tree Range: %abilitycastrange%"
+      "Active: ChopTargets a non-player enemy unit to remove 50% of its current HP.If cast on a tree, instantly destroys it.Unit Range: 350Tree Range: 350"
     ],
     "id": 239,
-    "img": "/apps/dota2/images/items/iron_talon_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/iron_talon_lg.png?t=1592658656576",
     "dname": "Iron Talon",
     "qual": "common",
     "cost": 301,
@@ -5953,7 +5953,7 @@
   },
   "recipe_abyssal_blade": {
     "id": 207,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Abyssal Blade Recipe",
     "cost": 1750,
     "notes": "",
@@ -5967,12 +5967,12 @@
   },
   "abyssal_blade": {
     "hint": [
-      "Active: Overwhelm Blinks to and stuns a target enemy unit for 2 seconds. Pierces Spell Immunity.Range: %abilitycastrange%",
+      "Active: Overwhelm Blinks to and stuns a target enemy unit for 2 seconds. Pierces Spell Immunity.Range: 600",
       "Passive: Bash Grants melee heroes a 25% chance on hit to stun the target for 1.5 seconds and deal 100 bonus physical damage.  Bash chance for ranged heroes is 10%.",
       "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 208,
-    "img": "/apps/dota2/images/items/abyssal_blade_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/abyssal_blade_lg.png?t=1592658656576",
     "dname": "Abyssal Blade",
     "qual": "epic",
     "cost": 6625,
@@ -6015,10 +6015,10 @@
   },
   "heavens_halberd": {
     "hint": [
-      "Active: DisarmPrevents a target from attacking for 3 seconds on melee targets, and 5 seconds on ranged targets.Range: %abilitycastrange%"
+      "Active: DisarmPrevents a target from attacking for 3 seconds on melee targets, and 5 seconds on ranged targets.Range: 600"
     ],
     "id": 210,
-    "img": "/apps/dota2/images/items/heavens_halberd_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/heavens_halberd_lg.png?t=1592658656576",
     "dname": "Heaven's Halberd",
     "qual": "artifact",
     "cost": 3450,
@@ -6063,7 +6063,7 @@
       "Toggle: Aura Deactivate to stop affecting non-hero units."
     ],
     "id": 212,
-    "img": "/apps/dota2/images/items/ring_of_aquila_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ring_of_aquila_lg.png?t=1592658656576",
     "dname": "Ring of Aquila",
     "qual": "rare",
     "cost": 0,
@@ -6108,7 +6108,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 214,
-    "img": "/apps/dota2/images/items/tranquil_boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tranquil_boots_lg.png?t=1592658656576",
     "dname": "Tranquil Boots",
     "qual": "rare",
     "cost": 975,
@@ -6140,10 +6140,10 @@
   },
   "shadow_amulet": {
     "hint": [
-      "Active: FadeGrants invisibility to you or a target allied hero as long as the target unit remains still.  Has a 1.25 second fade time, and breaks instantly upon moving. There is no cooldown when using this item on yourself.Range: %abilitycastrange%"
+      "Active: FadeGrants invisibility to you or a target allied hero as long as the target unit remains still.  Has a 1.25 second fade time, and breaks instantly upon moving. There is no cooldown when using this item on yourself.Range: 600"
     ],
     "id": 215,
-    "img": "/apps/dota2/images/items/shadow_amulet_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/shadow_amulet_lg.png?t=1592658656576",
     "dname": "Shadow Amulet",
     "cost": 1400,
     "notes": "",
@@ -6164,10 +6164,10 @@
   },
   "glimmer_cape": {
     "hint": [
-      "Active: Glimmer After a 0.6 second delay, grants invisibility and 45% magic resistance to you or a target allied unit for 5 seconds.Range: %abilitycastrange%Can be cast while channelling."
+      "Active: Glimmer After a 0.6 second delay, grants invisibility and 45% magic resistance to you or a target allied unit for 5 seconds.Range: 550Can be cast while channelling."
     ],
     "id": 254,
-    "img": "/apps/dota2/images/items/glimmer_cape_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/glimmer_cape_lg.png?t=1592658656576",
     "dname": "Glimmer Cape",
     "qual": "rare",
     "cost": 1950,
@@ -6201,7 +6201,7 @@
       "Pour this serum into the river to transform the water into liquid chrome for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1021,
-    "img": "/apps/dota2/images/items/river_painter_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter_lg.png?t=1592658656576",
     "dname": "River Vial: Chrome",
     "qual": "component",
     "cost": 0,
@@ -6219,7 +6219,7 @@
       "Pour this serum into the river to dry up the water for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect . Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1022,
-    "img": "/apps/dota2/images/items/river_painter2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter2_lg.png?t=1592658656576",
     "dname": "River Vial: Dry",
     "qual": "component",
     "cost": 0,
@@ -6237,7 +6237,7 @@
       "Pour this serum into the river to transform the water into a green slime for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1023,
-    "img": "/apps/dota2/images/items/river_painter3_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter3_lg.png?t=1592658656576",
     "dname": "River Vial: Slime",
     "qual": "component",
     "cost": 0,
@@ -6255,7 +6255,7 @@
       "Pour this serum into the river to make the water oily for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1024,
-    "img": "/apps/dota2/images/items/river_painter4_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter4_lg.png?t=1592658656576",
     "dname": "River Vial: Oil",
     "qual": "component",
     "cost": 0,
@@ -6273,7 +6273,7 @@
       "Pour this serum into the river to make the water electric for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1025,
-    "img": "/apps/dota2/images/items/river_painter5_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter5_lg.png?t=1592658656576",
     "dname": "River Vial: Electrified",
     "qual": "component",
     "cost": 0,
@@ -6291,7 +6291,7 @@
       "Pour this serum into the river to transform the water into a purple bubbling potion for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1026,
-    "img": "/apps/dota2/images/items/river_painter6_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter6_lg.png?t=1592658656576",
     "dname": "River Vial: Potion",
     "qual": "component",
     "cost": 0,
@@ -6309,7 +6309,7 @@
       "Pour this serum into the river to transform the water into blood for 900 seconds. Using this item on the river will permanently consume one charge from your Armory supply upon expiration of the effect. Charges do not get consumed if the effect is replaced by a stronger vial before expiration. Vials can only be used if at least one charge remains in your Armory. Charges will only be used by successfully enchanting the river, and will not be consumed if the item is sold, dropped, or destroyed during a game. You can only cast a vial on the river if there's not a stronger vial already in effect."
     ],
     "id": 1027,
-    "img": "/apps/dota2/images/items/river_painter7_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/river_painter7_lg.png?t=1592658656576",
     "dname": "River Vial: Blood",
     "qual": "component",
     "cost": 0,
@@ -6324,7 +6324,7 @@
   },
   "mutation_tombstone": {
     "id": 1028,
-    "img": "/apps/dota2/images/items/mutation_tombstone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mutation_tombstone_lg.png?t=1592658656576",
     "dname": "Tombstone",
     "qual": "consumable",
     "cost": 0,
@@ -6342,7 +6342,7 @@
       "Active: Blink Teleport to a target point up to 1200 units away."
     ],
     "id": 1029,
-    "img": "/apps/dota2/images/items/super_blink_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/super_blink_lg.png?t=1592658656576",
     "dname": "Super Blink Dagger",
     "cost": null,
     "notes": "",
@@ -6356,7 +6356,7 @@
   },
   "pocket_tower": {
     "id": 1030,
-    "img": "/apps/dota2/images/items/pocket_tower_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pocket_tower_lg.png?t=1592658656576",
     "dname": "Pocket Tower",
     "cost": null,
     "notes": "",
@@ -6370,7 +6370,7 @@
   },
   "pocket_roshan": {
     "id": 1032,
-    "img": "/apps/dota2/images/items/pocket_roshan_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pocket_roshan_lg.png?t=1592658656576",
     "dname": "Pocket Roshan",
     "qual": "rare",
     "cost": 1000,
@@ -6385,7 +6385,7 @@
   },
   "keen_optic": {
     "id": 287,
-    "img": "/apps/dota2/images/items/keen_optic_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/keen_optic_lg.png?t=1592658656576",
     "dname": "Keen Optic",
     "cost": 0,
     "notes": "",
@@ -6416,7 +6416,7 @@
       "Passive: Magic Amp Reduces magic resistance of the attacked enemy by 12%."
     ],
     "id": 288,
-    "img": "/apps/dota2/images/items/grove_bow_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/grove_bow_lg.png?t=1592658656576",
     "dname": "Grove Bow",
     "cost": 0,
     "notes": "",
@@ -6447,7 +6447,7 @@
       "Passive: Cooldown ReductionReduces the cooldown time of all spells and items by 13%"
     ],
     "id": 289,
-    "img": "/apps/dota2/images/items/quickening_charm_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/quickening_charm_lg.png?t=1592658656576",
     "dname": "Quickening Charm",
     "cost": 0,
     "notes": "",
@@ -6472,7 +6472,7 @@
       "Increases gold income and mana, while reducing outgoing attack damage."
     ],
     "id": 290,
-    "img": "/apps/dota2/images/items/philosophers_stone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/philosophers_stone_lg.png?t=1592658656576",
     "dname": "Philosopher's Stone",
     "cost": 0,
     "notes": "",
@@ -6509,7 +6509,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 291,
-    "img": "/apps/dota2/images/items/force_boots_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/force_boots_lg.png?t=1592658656576",
     "dname": "Force Boots",
     "cost": 0,
     "notes": "",
@@ -6534,7 +6534,7 @@
       "Passive: Greater Corruption Your attacks reduce the target's armor by -10 for 7 seconds."
     ],
     "id": 292,
-    "img": "/apps/dota2/images/items/desolator_2_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/desolator_2_lg.png?t=1592658656576",
     "dname": "Stygian Desolator",
     "cost": 0,
     "notes": "Armor reduction works on buildings.",
@@ -6559,7 +6559,7 @@
       "Passive: RebirthLethal damage is prevented and instead the wearer is healed to half health and non-ultimate ability cooldowns reset. Gets consumed on trigger."
     ],
     "id": 293,
-    "img": "/apps/dota2/images/items/phoenix_ash_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/phoenix_ash_lg.png?t=1592658656576",
     "dname": "Phoenix Ash",
     "cost": 0,
     "notes": "",
@@ -6576,7 +6576,7 @@
       "Increases cast range as well as daytime and night time vision."
     ],
     "id": 294,
-    "img": "/apps/dota2/images/items/seer_stone_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/seer_stone_lg.png?t=1592658656576",
     "dname": "Seer Stone",
     "cost": 0,
     "notes": "",
@@ -6612,7 +6612,7 @@
       "Consume Unbelievably Good MangoOverwhelms your hero, causing you to die. However, when you respawn, you will have all talents on both sides skilled."
     ],
     "id": 295,
-    "img": "/apps/dota2/images/items/greater_mango_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/greater_mango_lg.png?t=1592658656576",
     "dname": "Greater Mango",
     "cost": 0,
     "notes": "",
@@ -6626,10 +6626,10 @@
   },
   "elixer": {
     "hint": [
-      "Use: Consume Restores 500 health and 250 mana to the target over 6 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: %abilitycastrange%"
+      "Use: Consume Restores 500 health and 250 mana to the target over 6 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: 250"
     ],
     "id": 302,
-    "img": "/apps/dota2/images/items/elixer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/elixer_lg.png?t=1592658656576",
     "dname": "Elixir",
     "cost": 0,
     "notes": "",
@@ -6643,7 +6643,7 @@
   },
   "vampire_fangs": {
     "id": 297,
-    "img": "/apps/dota2/images/items/vampire_fangs_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/vampire_fangs_lg.png?t=1592658656576",
     "dname": "Vampire Fangs",
     "cost": 0,
     "notes": "",
@@ -6677,7 +6677,7 @@
       "Increases the wearer's armor, while reducing their attack speed."
     ],
     "id": 298,
-    "img": "/apps/dota2/images/items/craggy_coat_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/craggy_coat_lg.png?t=1592658656576",
     "dname": "Craggy Coat",
     "cost": 0,
     "notes": "",
@@ -6706,7 +6706,7 @@
       "Use: Imbue Instantly restores 450 health."
     ],
     "id": 299,
-    "img": "/apps/dota2/images/items/greater_faerie_fire_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/greater_faerie_fire_lg.png?t=1592658656576",
     "dname": "Greater Faerie Fire",
     "qual": "consumable",
     "cost": 0,
@@ -6732,7 +6732,7 @@
       "Increases all outgoing spell damage and debuff duration."
     ],
     "id": 300,
-    "img": "/apps/dota2/images/items/timeless_relic_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/timeless_relic_lg.png?t=1592658656576",
     "dname": "Timeless Relic",
     "cost": 0,
     "notes": "",
@@ -6762,7 +6762,7 @@
       "Passive: Echo Shield Block and reflect most targeted spells back to their caster once every 8 seconds."
     ],
     "id": 301,
-    "img": "/apps/dota2/images/items/mirror_shield_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mirror_shield_lg.png?t=1592658656576",
     "dname": "Mirror Shield",
     "cost": 0,
     "notes": "",
@@ -6784,7 +6784,7 @@
   },
   "recipe_ironwood_tree": {
     "id": 303,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Ironwood Tree Recipe",
     "cost": 1,
     "notes": "",
@@ -6798,10 +6798,10 @@
   },
   "ironwood_tree": {
     "hint": [
-      "Use: Plant Tree Targets the ground to plant a happy little tree that lasts for 20 seconds.Range: %abilitycastrange%"
+      "Use: Plant Tree Targets the ground to plant a happy little tree that lasts for 20 seconds.Range: 800"
     ],
     "id": 304,
-    "img": "/apps/dota2/images/items/ironwood_tree_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ironwood_tree_lg.png?t=1592658656576",
     "dname": "Ironwood Tree",
     "cost": 151,
     "notes": "",
@@ -6823,10 +6823,10 @@
   },
   "mango_tree": {
     "hint": [
-      "Use: Plant a Mango Tree Targets the ground to plant a mango tree that provides unlimited mango power. The tree generates Enchanted Mangoes every 60 seconds, and provides unobstructed vision in the area Range: %abilitycastrange%"
+      "Use: Plant a Mango Tree Targets the ground to plant a mango tree that provides unlimited mango power. The tree generates Enchanted Mangoes every 60 seconds, and provides unobstructed vision in the area Range: 200"
     ],
     "id": 328,
-    "img": "/apps/dota2/images/items/mango_tree_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mango_tree_lg.png?t=1592658656576",
     "dname": "Mango Tree",
     "qual": "consumable",
     "cost": null,
@@ -6845,7 +6845,7 @@
       "Use: Consume Grants a target allied unit a permanent buff that provides +2.25 Health Regen and +1.25 Mana Regen.Does not stack on the same unit."
     ],
     "id": 305,
-    "img": "/apps/dota2/images/items/royal_jelly_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/royal_jelly_lg.png?t=1592658656576",
     "dname": "Royal Jelly",
     "qual": "consumable",
     "cost": 0,
@@ -6864,7 +6864,7 @@
       "Increases both non-primary attributes."
     ],
     "id": 306,
-    "img": "/apps/dota2/images/items/pupils_gift_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pupils_gift_lg.png?t=1592658656576",
     "dname": "Pupil's Gift",
     "cost": 0,
     "notes": "",
@@ -6888,7 +6888,7 @@
       "Use: Consume Temporarily grants an allied target the Aghanim's Scepter buff for 3 minutes."
     ],
     "id": 307,
-    "img": "/apps/dota2/images/items/tome_of_aghanim_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/tome_of_aghanim_lg.png?t=1592658656576",
     "dname": "Tome of Aghanim",
     "cost": 0,
     "notes": "",
@@ -6902,10 +6902,10 @@
   },
   "repair_kit": {
     "hint": [
-      "Use: Building Repair Targets a building, restoring 40% of it's health over 30 seconds. Also grants +10 armor during this period. Range: %abilitycastrange%"
+      "Use: Building Repair Targets a building, restoring 40% of it's health over 30 seconds. Also grants +10 armor during this period. Range: 600"
     ],
     "id": 308,
-    "img": "/apps/dota2/images/items/repair_kit_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/repair_kit_lg.png?t=1592658656576",
     "dname": "Repair Kit",
     "qual": "consumable",
     "cost": 0,
@@ -6931,7 +6931,7 @@
       "Passive: Silence Strike The next attack silences the hit enemy for 1.5 seconds."
     ],
     "id": 309,
-    "img": "/apps/dota2/images/items/mind_breaker_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/mind_breaker_lg.png?t=1592658656576",
     "dname": "Mind Breaker",
     "cost": 0,
     "notes": "",
@@ -6961,7 +6961,7 @@
       "Passive: Charge LossLoses a charge on death. After all charges are lost, the item disappears."
     ],
     "id": 310,
-    "img": "/apps/dota2/images/items/third_eye_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/third_eye_lg.png?t=1592658656576",
     "dname": "Third Eye",
     "cost": 0,
     "notes": "",
@@ -6990,7 +6990,7 @@
       "Passive: Cooldown ReductionReduces the cooldown time of all spells and items by 20%."
     ],
     "id": 311,
-    "img": "/apps/dota2/images/items/spell_prism_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/spell_prism_lg.png?t=1592658656576",
     "dname": "Spell Prism",
     "cost": 0,
     "notes": "",
@@ -7021,7 +7021,7 @@
       "Passive: Hex Strike The next attack hexes the hit enemy into a frog for 1.5 seconds."
     ],
     "id": 325,
-    "img": "/apps/dota2/images/items/princes_knife_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/princes_knife_lg.png?t=1592658656576",
     "dname": "Prince's Knife",
     "cost": 0,
     "notes": "",
@@ -7045,7 +7045,7 @@
       "Increases the wearer's max health, while reducing their max mana."
     ],
     "id": 330,
-    "img": "/apps/dota2/images/items/witless_shako_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/witless_shako_lg.png?t=1592658656576",
     "dname": "Witless Shako",
     "cost": 0,
     "notes": "",
@@ -7074,7 +7074,7 @@
       "Passive: Critical Strike Empowers your next attack, causing it to be a critical strike dealing 130% damage."
     ],
     "id": 334,
-    "img": "/apps/dota2/images/items/imp_claw_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/imp_claw_lg.png?t=1592658656576",
     "dname": "Imp Claw",
     "cost": 0,
     "notes": "",
@@ -7099,7 +7099,7 @@
       "Active: Flicker Dispells debuffs and blinks you to a random spot within 600 range. Does not get disabled on incoming damage."
     ],
     "id": 335,
-    "img": "/apps/dota2/images/items/flicker_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/flicker_lg.png?t=1592658656576",
     "dname": "Flicker",
     "cost": 0,
     "notes": "",
@@ -7124,7 +7124,7 @@
       "Passive: Prescient Aura Lowers Scan cooldown by 50% . Increases attack and cast range of allies in a 1200 unit radius."
     ],
     "id": 336,
-    "img": "/apps/dota2/images/items/spy_gadget_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/spy_gadget_lg.png?t=1592658656576",
     "dname": "Telescope",
     "cost": 0,
     "notes": "",
@@ -7159,7 +7159,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 326,
-    "img": "/apps/dota2/images/items/spider_legs_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/spider_legs_lg.png?t=1592658656576",
     "dname": "Spider Legs",
     "cost": 0,
     "notes": "",
@@ -7189,7 +7189,7 @@
       "Passive: Death Delay Survive for an extra 5 seconds after receiving a killing blow."
     ],
     "id": 327,
-    "img": "/apps/dota2/images/items/helm_of_the_undying_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/helm_of_the_undying_lg.png?t=1592658656576",
     "dname": "Helm of the Undying",
     "cost": 0,
     "notes": "",
@@ -7216,7 +7216,7 @@
       " Intelligence: +6% Spell Amp"
     ],
     "id": 331,
-    "img": "/apps/dota2/images/items/vambrace_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/vambrace_lg.png?t=1592658656576",
     "dname": "Vambrace",
     "qual": "common",
     "cost": 0,
@@ -7243,10 +7243,10 @@
   },
   "horizon": {
     "hint": [
-      "Active: Blink Strike Targets a unit to teleport to them. Knocks enemies back 250 distance and disables them for 1 second. Range: %abilitycastrange%"
+      "Active: Blink Strike Targets a unit to teleport to them. Knocks enemies back 250 distance and disables them for 1 second. Range: 1600"
     ],
     "id": 312,
-    "img": "/apps/dota2/images/items/horizon_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/horizon_lg.png?t=1592658656576",
     "dname": "Horizon",
     "cost": 0,
     "notes": "",
@@ -7263,7 +7263,7 @@
       "Use: Consume Grants the target the bonuses of every Power Rune for 50 seconds. Each use consumes a charge."
     ],
     "id": 313,
-    "img": "/apps/dota2/images/items/fusion_rune_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/fusion_rune_lg.png?t=1592658656576",
     "dname": "Fusion Rune",
     "cost": 0,
     "notes": "",
@@ -7280,7 +7280,7 @@
       "Passive: Water Regen Provides you with 8 HP regen and 4 mana regen while in the river."
     ],
     "id": 354,
-    "img": "/apps/dota2/images/items/ocean_heart_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ocean_heart_lg.png?t=1592658656576",
     "dname": "Ocean Heart",
     "cost": 0,
     "notes": "",
@@ -7302,7 +7302,7 @@
   },
   "broom_handle": {
     "id": 355,
-    "img": "/apps/dota2/images/items/broom_handle_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/broom_handle_lg.png?t=1592658656576",
     "dname": "Broom Handle",
     "cost": 0,
     "notes": "",
@@ -7336,10 +7336,10 @@
   },
   "trusty_shovel": {
     "hint": [
-      "Active: Dig Channel for %abilitychanneltime% second. Can find a Bounty Rune, a Flask, a TP Scroll, or an enemy Kobold."
+      "Active: Dig Channel for 1 second. Can find a Bounty Rune, a Flask, a TP Scroll, or an enemy Kobold."
     ],
     "id": 356,
-    "img": "/apps/dota2/images/items/trusty_shovel_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/trusty_shovel_lg.png?t=1592658656576",
     "dname": "Trusty Shovel",
     "cost": 0,
     "notes": "",
@@ -7364,7 +7364,7 @@
       "Increases the wearer's magic resistance and magic damage, while decreasing their armor."
     ],
     "id": 357,
-    "img": "/apps/dota2/images/items/nether_shawl_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/nether_shawl_lg.png?t=1592658656576",
     "dname": "Nether Shawl",
     "cost": 0,
     "notes": "",
@@ -7400,7 +7400,7 @@
       "Passive: Afterburn Causes attacks to burn the enemy, dealing 18 damage per second for 3 seconds. Affects buildings."
     ],
     "id": 358,
-    "img": "/apps/dota2/images/items/dragon_scale_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dragon_scale_lg.png?t=1592658656576",
     "dname": "Dragon Scale",
     "cost": 0,
     "notes": "",
@@ -7431,7 +7431,7 @@
       "Active: Life Essence Increases your current and max health by 425 for 15 seconds."
     ],
     "id": 359,
-    "img": "/apps/dota2/images/items/essence_ring_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/essence_ring_lg.png?t=1592658656576",
     "dname": "Essence Ring",
     "cost": 0,
     "notes": "",
@@ -7459,10 +7459,10 @@
   },
   "clumsy_net": {
     "hint": [
-      "Active: Ensnare Ensnares the target enemy and yourself for 1.75 seconds. Range: %abilitycastrange%"
+      "Active: Ensnare Ensnares the target enemy and yourself for 1.75 seconds. Range: 650"
     ],
     "id": 360,
-    "img": "/apps/dota2/images/items/clumsy_net_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/clumsy_net_lg.png?t=1592658656576",
     "dname": "Clumsy Net",
     "cost": 0,
     "notes": "",
@@ -7493,7 +7493,7 @@
       "Passive: Certain Strike Empowers your next attack with 300 bonus magical damage and True Strike. Ranged Attackers have +400 bonus range for the attack."
     ],
     "id": 361,
-    "img": "/apps/dota2/images/items/enchanted_quiver_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/enchanted_quiver_lg.png?t=1592658656576",
     "dname": "Enchanted Quiver",
     "cost": 0,
     "notes": "",
@@ -7511,7 +7511,7 @@
       "Active: Solitary Disguise Casts Smoke of Deceit on yourself only."
     ],
     "id": 362,
-    "img": "/apps/dota2/images/items/ninja_gear_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ninja_gear_lg.png?t=1592658656576",
     "dname": "Ninja Gear",
     "cost": 0,
     "notes": "",
@@ -7543,7 +7543,7 @@
       " Passive: Illusion MasteryIncreases outgoing damage of all units and illusions controlled by the hero by 10%."
     ],
     "id": 363,
-    "img": "/apps/dota2/images/items/illusionsts_cape_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/illusionsts_cape_lg.png?t=1592658656576",
     "dname": "Illusionist's Cape",
     "cost": 0,
     "notes": "",
@@ -7589,7 +7589,7 @@
       "Active: Havoc Knocks back enemies in 350 range around you, slowing them by 50% for 3 seconds and dealing 225 + 1x your str as magical damage."
     ],
     "id": 364,
-    "img": "/apps/dota2/images/items/havoc_hammer_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/havoc_hammer_lg.png?t=1592658656576",
     "dname": "Havoc Hammer",
     "cost": 0,
     "notes": "",
@@ -7620,7 +7620,7 @@
       "Passive: Rejuvenate  When the wearer's health falls below 20%, they will receive a hard dispel and be healed for 300 health."
     ],
     "id": 365,
-    "img": "/apps/dota2/images/items/panic_button_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/panic_button_lg.png?t=1592658656576",
     "dname": "Magic Lamp",
     "cost": 0,
     "notes": "",
@@ -7645,7 +7645,7 @@
       "Increases your primary attribute by 75."
     ],
     "id": 366,
-    "img": "/apps/dota2/images/items/apex_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/apex_lg.png?t=1592658656576",
     "dname": "Apex",
     "cost": 0,
     "notes": "",
@@ -7663,7 +7663,7 @@
       "Passive: Knockback Knocks back enemies 50 distance and deals 40 pure damage with every attack."
     ],
     "id": 367,
-    "img": "/apps/dota2/images/items/ballista_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ballista_lg.png?t=1592658656576",
     "dname": "Ballista",
     "cost": 0,
     "notes": "",
@@ -7692,7 +7692,7 @@
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 368,
-    "img": "/apps/dota2/images/items/woodland_striders_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/woodland_striders_lg.png?t=1592658656576",
     "dname": "Woodland Striders",
     "cost": 0,
     "notes": "",
@@ -7720,7 +7720,7 @@
   },
   "recipe_trident": {
     "id": 275,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Trident Recipe",
     "cost": 1,
     "notes": "",
@@ -7738,7 +7738,7 @@
       "Active: Greater Demonic Summoning Summon 2 sets of Level 3 Necronomicon Units that last 75 seconds. Units have 50% more health and damage."
     ],
     "id": 370,
-    "img": "/apps/dota2/images/items/demonicon_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/demonicon_lg.png?t=1592658656576",
     "dname": "Book of the Dead",
     "cost": 0,
     "notes": "",
@@ -7766,7 +7766,7 @@
   },
   "recipe_fallen_sky": {
     "id": 317,
-    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/recipe_lg.png?t=1592658656576",
     "dname": "Recipe: Fallen Sky",
     "cost": 1,
     "notes": "",
@@ -7780,10 +7780,10 @@
   },
   "fallen_sky": {
     "hint": [
-      "Active: Fallen Sky Transform into a meteor that strikes down at the target area after 0.5 seconds in a 315 AoE, stunning enemies for 2 seconds and dealing impact damage. Continues to deal damage every 1 seconds to enemy units and buildings for 6 seconds.Building Impact Damage: 75 Building Over Time Damage: 50 Non-Building Impact Damage: 150 Non-Building Over Time Damage: 90 Range: %abilitycastrange%"
+      "Active: Fallen Sky Transform into a meteor that strikes down at the target area after 0.5 seconds in a 315 AoE, stunning enemies for 2 seconds and dealing impact damage. Continues to deal damage every 1 seconds to enemy units and buildings for 6 seconds.Building Impact Damage: 75 Building Over Time Damage: 50 Non-Building Impact Damage: 150 Non-Building Over Time Damage: 90 Range: 1600"
     ],
     "id": 371,
-    "img": "/apps/dota2/images/items/fallen_sky_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/fallen_sky_lg.png?t=1592658656576",
     "dname": "Fallen Sky",
     "cost": 4751,
     "notes": "",
@@ -7830,7 +7830,7 @@
       "Passive: Kill Bounty Steals 300 gold when you kill an enemy hero."
     ],
     "id": 372,
-    "img": "/apps/dota2/images/items/pirate_hat_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/pirate_hat_lg.png?t=1592658656576",
     "dname": "Pirate Hat",
     "cost": 0,
     "notes": "",
@@ -7855,7 +7855,7 @@
       "Active Teleport instantly anywhere on the map."
     ],
     "id": 373,
-    "img": "/apps/dota2/images/items/dimensional_doorway_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/dimensional_doorway_lg.png?t=1592658656576",
     "dname": "Dimensional Doorway",
     "cost": 0,
     "notes": "",
@@ -7872,7 +7872,7 @@
       "Active: Reset Item Cooldowns Reset the cooldown on all items (except Refresher Orb)."
     ],
     "id": 374,
-    "img": "/apps/dota2/images/items/ex_machina_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/ex_machina_lg.png?t=1592658656576",
     "dname": "Ex Machina",
     "cost": 0,
     "notes": "",
@@ -7894,7 +7894,7 @@
   },
   "faded_broach": {
     "id": 375,
-    "img": "/apps/dota2/images/items/faded_broach_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/faded_broach_lg.png?t=1592658656576",
     "dname": "Faded Broach",
     "cost": 0,
     "notes": "",
@@ -7925,7 +7925,7 @@
       "Passive: Greater Healing Amplifies the wearer's Regeneration, Healing and Lifesteal by 17%."
     ],
     "id": 376,
-    "img": "/apps/dota2/images/items/paladin_sword_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/paladin_sword_lg.png?t=1592658656576",
     "dname": "Paladin Sword",
     "cost": 0,
     "notes": "",
@@ -7955,7 +7955,7 @@
       "Active: Lesser Avatar Grants Spell Immunity for 2 seconds."
     ],
     "id": 377,
-    "img": "/apps/dota2/images/items/minotaur_horn_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/minotaur_horn_lg.png?t=1592658656576",
     "dname": "Minotaur Horn",
     "cost": 0,
     "notes": "",
@@ -7980,7 +7980,7 @@
       "Passive: Impeding Corruption Attacks reduce the target's armor and movement speed. Slow amount varies based on whether the wearer is melee or ranged."
     ],
     "id": 378,
-    "img": "/apps/dota2/images/items/orb_of_destruction_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/orb_of_destruction_lg.png?t=1592658656576",
     "dname": "Orb of Destruction",
     "cost": 0,
     "notes": "",
@@ -8016,7 +8016,7 @@
   },
   "the_leveller": {
     "id": 379,
-    "img": "/apps/dota2/images/items/the_leveller_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/the_leveller_lg.png?t=1592658656576",
     "dname": "The Leveller",
     "cost": 0,
     "notes": "",
@@ -8046,7 +8046,7 @@
       "Active: Replenish Mana Restores 75 mana to all nearby allies.  Radius: 1200"
     ],
     "id": 349,
-    "img": "/apps/dota2/images/items/arcane_ring_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/arcane_ring_lg.png?t=1592658656576",
     "dname": "Arcane Ring",
     "cost": 0,
     "notes": "",
@@ -8077,7 +8077,7 @@
       "Increases the wearer's attack damage, magic and status resistance."
     ],
     "id": 381,
-    "img": "/apps/dota2/images/items/titan_sliver_lg.png?t=1592630854200",
+    "img": "/apps/dota2/images/items/titan_sliver_lg.png?t=1592658656576",
     "dname": "Titan Sliver",
     "cost": 0,
     "notes": "",

--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -38,6 +38,16 @@ const badNames = [
   "npc_dota_hero_base",
   "npc_dota_hero_target_dummy",
 ];
+
+const extraAttribKeys = [
+  "AbilityCastRange",
+  "AbilityChargeRestoreTime", 
+  "AbilityDuration",
+  "AbilityChannelTime",
+  "AbilityCastPoint",
+  "AbilityCharges"
+];
+
 const now = Number(new Date());
 
 const sources = [
@@ -78,27 +88,10 @@ const sources = [
             ...replaceSpecialAttribs(
               strings[`DOTA_Tooltip_ability_${key}_Description`],
               scripts[key].AbilitySpecial,
-              true
+              true,
+              scripts[key]
             ),
           };
-          if (item.use) {
-            item.use.forEach(
-              (entry, i) =>
-                (item.use[i].desc = item.use[i].desc.replace(
-                  "%abilitycastrange%",
-                  scripts[key].AbilityCastRange
-                ))
-            );
-          }
-          if (item.active) {
-            item.active.forEach(
-              (entry, i) =>
-                (item.active[i].desc = item.active[i].desc.replace(
-                  "%abilitycastrange%",
-                  scripts[key].AbilityCastRange
-                ))
-            );
-          }
 
           item.id = parseInt(scripts[key].ID);
           item.img = `/apps/dota2/images/items/${key.replace(
@@ -349,7 +342,9 @@ const sources = [
 
           ability.desc = replaceSpecialAttribs(
             strings[`DOTA_Tooltip_ability_${key}_Description`],
-            scripts[key].AbilitySpecial
+            scripts[key].AbilitySpecial,
+            false,
+            scripts[key]
           );
           ability.dmg =
             scripts[key].AbilityDamage &&
@@ -906,11 +901,31 @@ function replaceSValues(template, attribs) {
 
 // Formats templates like "Storm's movement speed is %storm_move_speed%" with "Storm's movement speed is 32"
 // args are the template, and a list of attribute dictionaries, like the ones in AbilitySpecial for each ability in the npc_abilities.json from the vpk
-function replaceSpecialAttribs(template, attribs, isItem = false) {
+function replaceSpecialAttribs(template, attribs, isItem = false, allData={}) {
   if (!template) {
     return template;
   }
   if (attribs) {
+    //additional special ability keys being catered
+    extraAttribKeys.forEach(abilitykey => {
+      if (abilitykey in allData) {
+        let value = allData[abilitykey].split(' '); //can have multiple values
+        value = value.length === 1 ? Number(value[0]) : value.map(v => Number(v));
+        attribs.push({[abilitykey.toLowerCase()]: value});
+        //these are also present with another attrib name
+        if (abilitykey === "AbilityChargeRestoreTime") { 
+          attribs.push({"charge_restore_time": value});
+        }
+        if (abilitykey === "AbilityCharges") {
+          attribs.push({"max_charges": value});
+        }
+      }
+    });
+
+    if (template.includes("%customval_team_tomes_used%")){ //in-game line not required in tooltip
+      template = template.replace(/[ a-zA-Z]+: %\w+%/g,"");
+    }
+
     template = template.replace(/%([^% ]*)%/g, function (str, name) {
       if (name == "") {
         return "%";
@@ -923,6 +938,13 @@ function replaceSpecialAttribs(template, attribs, isItem = false) {
         attr = attribs.find((attr) => name in attr);
       }
       if (!attr) {
+        if (name === "lifesteal") { //special cases, in terms of template context and dota2 gamepedia
+          return attribs.find(obj => "lifesteal_percent" in obj).lifesteal_percent; 
+        }
+        else if (name === "movement_slow") {
+          return attribs.find(obj => "damage_pct" in obj).damage_pct; 
+        }
+
         console.log(`cant find attribute %${name}%`);
         return `%${name}%`;
       }


### PR DESCRIPTION
Fixes remaining ability and item attributes in replaceSpecialAttribs.
Removes extra item.active
and item.use lines. Fixes the NaN
value bug. Caters special cases:
movement_slow, lifesteal, customval_team_tomes_used

Closes #78

Also regenerates the build (items and abilities JSON)