### PR TITLE
Fixed indexing of hero abilities and talents

### DIFF
--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -456,10 +456,11 @@ const sources = [
           const newHero = { abilities: [], talents: [] };
           let talentCounter = 2;
           Object.keys(DOTAHeroes[heroKey]).forEach(function (key) {
+            var talentIndexStart = DOTAHeroes[heroKey]['AbilityTalentStart'] != undefined ? DOTAHeroes[heroKey]['AbilityTalentStart'] : 10
             var abilityRegexMatch = key.match(/Ability([0-9]+)/);
-            if (abilityRegexMatch) {
+            if (abilityRegexMatch && DOTAHeroes[heroKey][key] != '') {
               var abilityNum = parseInt(abilityRegexMatch[1]);
-              if (abilityNum < 10) {
+              if (abilityNum < talentIndexStart) {
                 newHero["abilities"].push(DOTAHeroes[heroKey][key]);
               } else {
                 // -8 not -10 because going from 0-based index -> 1 and flooring divison result


### PR DESCRIPTION
Invoker, Morphling, Rubick, and Keeper of the light have an unusual number of abilities which causes some of their abilities to be listed as talents

To properly separate the abilities from the talents, we should use the `AbilityTalentStart` value instead of a fixed value of `10`.

Also added a condition for filtering out abilities with empty strings as values _(Although so far, only Invoker has one)_ since this also messed up the talent indexing.
