### PR TITLE
Fix abilities dnames

### DIFF
--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -318,16 +318,13 @@ const sources = [
           );
           
           // Check for bonus s-values
-          if (ability.dname.includes('bonus_')) {
-            if (scripts[key].ad_linked_abilities && scripts[scripts[key].ad_linked_abilities]) {
-              ability.dname = replaceBonusSValues(
-                key,
-                ability.dname,
-                scripts[scripts[key].ad_linked_abilities].AbilityValues
-              );
-            } else {
-              // TODO: find talent bonus values from heroe's base abilities
-            }
+          // TODO: find other missing talent bonus values from heroe's base abilities
+          if (scripts[key].ad_linked_abilities && scripts[scripts[key].ad_linked_abilities]) {
+            ability.dname = replaceBonusSValues(
+              key,
+              ability.dname,
+              scripts[scripts[key].ad_linked_abilities].AbilityValues
+            );
           }
 
           ability.behavior =

--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -317,8 +317,8 @@ const sources = [
             scripts[key].AbilitySpecial ?? (scripts[key].AbilityValues ? [scripts[key].AbilityValues] : undefined)
           );
           
-          // Check for bonus s-values
-          // TODO: find other missing talent bonus values from heroe's base abilities
+          // Check for unreplaced `s:bonus_<talent>`
+          // TODO: Create a replace function for the remaining `s:bonus_<talent>` templates whose values are placed in one of the hero's base abilities.
           if (scripts[key].ad_linked_abilities && scripts[scripts[key].ad_linked_abilities]) {
             ability.dname = replaceBonusSValues(
               key,

--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -327,14 +327,6 @@ const sources = [
             );
           }
 
-          // Clean Dname
-          if (ability.dname) {
-            ability.dname = ability.dname
-              .replace(/\+\+/g, '+')
-              .replace(/\-\-/g, '-')
-              .replace(/\+\-/g, '-');
-          }
-
           ability.behavior =
             formatBehavior(scripts[key].AbilityBehavior) || undefined;
           ability.dmg_type =
@@ -976,7 +968,8 @@ function replaceSValues(template, attribs) {
     });
     Object.keys(values).forEach((key) => {
       if (typeof values[key] != 'object') { // TODO: fix special_bonus_unique_bloodseeker_rupture_charges
-        template = template.replace(`{s:${key}}`, values[key]);
+        template = template
+          .replace(`{s:${key}}`, values[key]);
       }
     });
   }
@@ -987,11 +980,17 @@ function replaceBonusSValues(key, template, attribs) {
   if (template && attribs) {
     Object.keys(attribs).forEach((bonus) => {
       if (typeof attribs[bonus] == 'object' && attribs[bonus].hasOwnProperty(key)) {
+        // remove redundant signs
+        var bonus_value = attribs[bonus][key]
+          .replace('+', '')
+          .replace('-', '')
+          .replace('x', '');
+
         template = template
           // Most of the time, the bonus value template is named bonus_<bonus_key>
-          .replace(`{s:bonus_${bonus}}`, attribs[bonus][key])
+          .replace(`{s:bonus_${bonus}}`, bonus_value)
           // But sometimes, it's just value
-          .replace(`{s:value}`, attribs[bonus][key]);
+          .replace(`{s:value}`, bonus_value);
       }
     });
   }

--- a/tasks/updateconstants.js
+++ b/tasks/updateconstants.js
@@ -327,6 +327,14 @@ const sources = [
             );
           }
 
+          // Clean Dname
+          if (ability.dname) {
+            ability.dname = ability.dname
+              .replace(/\+\+/g, '+')
+              .replace(/\-\-/g, '-')
+              .replace(/\+\-/g, '-');
+          }
+
           ability.behavior =
             formatBehavior(scripts[key].AbilityBehavior) || undefined;
           ability.dmg_type =
@@ -967,7 +975,9 @@ function replaceSValues(template, attribs) {
       values[key] = attrib[key];
     });
     Object.keys(values).forEach((key) => {
-      template = template.replace(`{s:${key}}`, values[key]);
+      if (typeof values[key] != 'object') { // TODO: fix special_bonus_unique_bloodseeker_rupture_charges
+        template = template.replace(`{s:${key}}`, values[key]);
+      }
     });
   }
   return template;
@@ -981,10 +991,7 @@ function replaceBonusSValues(key, template, attribs) {
           // Most of the time, the bonus value template is named bonus_<bonus_key>
           .replace(`{s:bonus_${bonus}}`, attribs[bonus][key])
           // But sometimes, it's just value
-          .replace(`{s:value}`, attribs[bonus][key])
-          // And sometimes, the + and - signs are doubled
-          .replace(`++`, '+')
-          .replace(`--`, '-');
+          .replace(`{s:value}`, attribs[bonus][key]);
       }
     });
   }


### PR DESCRIPTION
Fixed unreplaced `s:value` abilities dname.
Added replace function for `s:bonus_<talent>` abilities dname.

Result:
Fixed **4** of 5 `s:value` ability dnames. _1 remaining_.
Fixed **58** of 83 `s:bonus_x` ability  dnames. _25 remaining_.

TODO:
- Create a replace function for the remaining `s:bonus_<talent>` templates whose values are placed in one of the hero's base abilities.
-  Fix special_bonus_unique_bloodseeker_rupture_charges dname replacement