### PR TITLE
Updated some items qual based on dota client:

### DIFF
--- a/build/items.json
+++ b/build/items.json
@@ -1618,7 +1618,7 @@
     "id": 56,
     "img": "/apps/dota2/images/dota_react/items/ring_of_health.png?t=1593393829403",
     "dname": "Ring of Health",
-    "qual": "component",
+    "qual": "secret_shop",
     "cost": 825,
     "notes": "",
     "attrib": [
@@ -1640,7 +1640,7 @@
     "id": 57,
     "img": "/apps/dota2/images/dota_react/items/void_stone.png?t=1593393829403",
     "dname": "Void Stone",
-    "qual": "component",
+    "qual": "secret_shop",
     "cost": 825,
     "notes": "",
     "attrib": [
@@ -1756,7 +1756,7 @@
     "id": 593,
     "img": "/apps/dota2/images/dota_react/items/fluffy_hat.png?t=1593393829403",
     "dname": "Fluffy Hat",
-    "qual": "secret_shop",
+    "qual": "component",
     "cost": 250,
     "notes": "",
     "attrib": [


### PR DESCRIPTION
Rignt of health and void stone should be qual at secret shop; Fluffy hat should be qual component or other

![image](https://user-images.githubusercontent.com/4952611/196201304-96927a1f-e06b-401f-80fd-171160b75d2b.png)
