### PR TITLE
Added misses tier key/value for broom_handle

### DIFF
--- a/build/items.json
+++ b/build/items.json
@@ -7590,7 +7590,8 @@
     "lore": "The surprisingly dangerous creation of an apprentice sorcerer with a strange fondness for brooms.",
     "components": null,
     "created": false,
-    "charges": false
+    "charges": false,
+    "tier": 1
   },
   "trusty_shovel": {
     "hint": [


### PR DESCRIPTION
FYI: Broom handle should be tier 1 of Neutral items  

Referece dota2 client  
![image](https://user-images.githubusercontent.com/4952611/196204025-f4399b6b-abd1-4cb1-9896-688fc2619ddd.png)
