### PR TITLE
Outworld Destroyer localized_name fix

### DIFF
--- a/build/heroes.json
+++ b/build/heroes.json
@@ -2982,7 +2982,7 @@
     "legs": 4,
     "day_vision": 1800,
     "night_vision": 800,
-    "localized_name": "Outworld Devourer"
+    "localized_name": "Outworld Destroyer"
   },
   "77": {
     "id": 77,


### PR DESCRIPTION
Fixed the hero name to the correct value. This follows the changes discussed in [issue #109](https://github.com/odota/dotaconstants/issues/109). The name was mistakenly reverted to the old value in commit [a1f3974](https://github.com/odota/dotaconstants/commit/a1f39740a3f37fc248051829eb1bcc1befe7676d).