### PR TITLE
fix vengeful spirit melee facet name

### DIFF
--- a/build/hero_abilities.json
+++ b/build/hero_abilities.json
@@ -1315,7 +1315,7 @@
       },
       {
         "id": 1,
-        "name": "vvengefulspirit_melee",
+        "name": "vengefulspirit_melee",
         "icon": "fist",
         "color": "Blue",
         "gradient_id": 1,


### PR DESCRIPTION
Seem like a mistake, let me know if it isn't.