### PR TITLE
Fix unresolved special bonus placeholders

### DIFF
--- a/build/abilities.json
+++ b/build/abilities.json
@@ -1596,10 +1596,10 @@
         "key": "bonus_cdr",
         "header": "COOLDOWN REDUCTION:",
         "value": [
+          "8%",
+          "9%",
           "10%",
-          "11%",
-          "12%",
-          "14%"
+          "11%"
         ]
       },
       {
@@ -1959,7 +1959,7 @@
       {
         "key": "passive_reflection_bonus_per_interval",
         "header": "PASSIVE REFLECTION BONUS PER INTERVAL:",
-        "value": "2",
+        "value": "1.5",
         "generated": true
       },
       {
@@ -2045,13 +2045,13 @@
       {
         "key": "aura_duration",
         "header": "AURA DURATION:",
-        "value": "10",
+        "value": "15",
         "generated": true
       },
       {
         "key": "hp_restoration_pct",
         "header": "HP RESTORATION PCT:",
-        "value": "2",
+        "value": "2.25",
         "generated": true
       },
       {
@@ -9012,6 +9012,300 @@
     ],
     "img": "/apps/dota2/images/dota_react/abilities/deity_blessing_deep_ones.png"
   },
+  "seasonal_dark_carnival_balloon": {
+    "dname": "Carnival Balloon",
+    "behavior": [
+      "Point Target",
+      "Unit Target"
+    ],
+    "target_team": "Both",
+    "target_type": [
+      "Hero",
+      "Basic"
+    ],
+    "desc": "Release a balloon",
+    "dmg": "0",
+    "attrib": [
+      {
+        "key": "speed",
+        "header": "SPEED:",
+        "value": "1500",
+        "generated": true
+      },
+      {
+        "key": "min_distance_before_bounce",
+        "header": "MIN DISTANCE BEFORE BOUNCE:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "drag",
+        "header": "DRAG:",
+        "value": "7",
+        "generated": true
+      },
+      {
+        "key": "duration",
+        "header": "DURATION:",
+        "value": "20",
+        "generated": true
+      },
+      {
+        "key": "max_height",
+        "header": "MAX HEIGHT:",
+        "value": "300",
+        "generated": true
+      },
+      {
+        "key": "max_vertical_move_time",
+        "header": "MAX VERTICAL MOVE TIME:",
+        "value": "0.5",
+        "generated": true
+      },
+      {
+        "key": "bounce_turn_angle",
+        "header": "BOUNCE TURN ANGLE:",
+        "value": "45",
+        "generated": true
+      },
+      {
+        "key": "bounce_turn_angle_tree",
+        "header": "BOUNCE TURN ANGLE TREE:",
+        "value": "30",
+        "generated": true
+      },
+      {
+        "key": "bounce_delay",
+        "header": "BOUNCE DELAY:",
+        "value": "0.6",
+        "generated": true
+      },
+      {
+        "key": "multi_spawn",
+        "header": "MULTI SPAWN:",
+        "value": [
+          "0",
+          "0",
+          "0",
+          "0",
+          "1"
+        ],
+        "generated": true
+      },
+      {
+        "key": "different_types",
+        "header": "DIFFERENT TYPES:",
+        "value": [
+          "0",
+          "0",
+          "1"
+        ],
+        "generated": true
+      },
+      {
+        "key": "additional_charges_after_max_level",
+        "header": "ADDITIONAL CHARGES AFTER MAX LEVEL:",
+        "value": "5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "800",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "CAST TIME:",
+        "value": "0.2",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": [
+          "5",
+          "10"
+        ],
+        "generated": true
+      }
+    ],
+    "lore": "Prizes!",
+    "mc": "0",
+    "cd": [
+      "60",
+      "60",
+      "40",
+      "40"
+    ],
+    "img": "/apps/dota2/images/dota_react/abilities/seasonal_dark_carnival_balloon.png"
+  },
+  "seasonal_dark_carnival_firework": {
+    "dname": "Carnival Firework",
+    "behavior": "Point Target",
+    "desc": "Shoot a firework into the air.",
+    "dmg": "0",
+    "attrib": [
+      {
+        "key": "radius",
+        "header": "RADIUS:",
+        "value": "600",
+        "generated": true
+      },
+      {
+        "key": "speed",
+        "header": "SPEED:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "linger_duration",
+        "header": "LINGER DURATION:",
+        "value": "5",
+        "generated": true
+      },
+      {
+        "key": "explosion_type",
+        "header": "EXPLOSION TYPE:",
+        "value": [
+          "1",
+          "1",
+          "2",
+          "2",
+          "3"
+        ],
+        "generated": true
+      },
+      {
+        "key": "additional_charges_after_max_level",
+        "header": "ADDITIONAL CHARGES AFTER MAX LEVEL:",
+        "value": "5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "CAST TIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": [
+          "5",
+          "10"
+        ],
+        "generated": true
+      }
+    ],
+    "lore": "Boom!",
+    "mc": "0",
+    "cd": [
+      "60",
+      "60",
+      "40",
+      "40"
+    ],
+    "img": "/apps/dota2/images/dota_react/abilities/seasonal_dark_carnival_firework.png"
+  },
+  "seasonal_dark_carnival_pie": {
+    "dname": "Carnival Pie",
+    "behavior": "Unit Target",
+    "target_team": "Both",
+    "target_type": "Hero",
+    "desc": "Throw a pie",
+    "dmg": "0",
+    "attrib": [
+      {
+        "key": "projectile_speed",
+        "header": "PROJECTILE SPEED:",
+        "value": "1100",
+        "generated": true
+      },
+      {
+        "key": "golden_pie",
+        "header": "GOLDEN PIE:",
+        "value": [
+          "0",
+          "0",
+          "0",
+          "0",
+          "1"
+        ],
+        "generated": true
+      },
+      {
+        "key": "bounce",
+        "header": "BOUNCE:",
+        "value": [
+          "0",
+          "0",
+          "1"
+        ],
+        "generated": true
+      },
+      {
+        "key": "additional_charges_after_max_level",
+        "header": "ADDITIONAL CHARGES AFTER MAX LEVEL:",
+        "value": "5",
+        "generated": true
+      },
+      {
+        "key": "abilitycastrange",
+        "header": "CAST RANGE:",
+        "value": "1200",
+        "generated": true
+      },
+      {
+        "key": "charge_restore_time",
+        "header": "CHARGE RESTORE TIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "abilitycastpoint",
+        "header": "CAST TIME:",
+        "value": "0",
+        "generated": true
+      },
+      {
+        "key": "max_charges",
+        "header": "MAX CHARGES:",
+        "value": [
+          "5",
+          "10"
+        ],
+        "generated": true
+      }
+    ],
+    "lore": "Splat!",
+    "mc": "0",
+    "cd": [
+      "60",
+      "60",
+      "60",
+      "40"
+    ],
+    "img": "/apps/dota2/images/dota_react/abilities/seasonal_dark_carnival_pie.png"
+  },
   "antimage_mana_break": {
     "dname": "Mana Break",
     "behavior": "Passive",
@@ -9022,7 +9316,7 @@
       {
         "key": "percent_damage_per_burn",
         "header": "MANA BURNED AS DAMAGE:",
-        "value": "50"
+        "value": "60"
       },
       {
         "key": "mana_per_hit",
@@ -9038,10 +9332,10 @@
         "key": "mana_per_hit_pct",
         "header": "MAX MANA BURNED PER HIT:",
         "value": [
-          "1.6",
-          "2.4",
-          "3.2",
-          "4"
+          "1.8",
+          "2.7",
+          "3.6",
+          "4.5"
         ]
       },
       {
@@ -9071,7 +9365,7 @@
     "is_innate": true,
     "behavior": "Passive",
     "bkbpierce": "No",
-    "desc": "Attacks slow enemies based on how much mana they are missing. Min slow at 50% mana, up to max slow at 0% mana. No effect if enemy is above 50% mana.",
+    "desc": "Attacks slow enemies based on how much mana they are missing. Min slow at 60% mana, up to max slow at 0% mana. No effect if enemy is above 60% mana.",
     "attrib": [
       {
         "key": "move_slow_min",
@@ -9086,7 +9380,7 @@
       {
         "key": "mana_threshold",
         "header": "MANA THRESHOLD:",
-        "value": "50",
+        "value": "60",
         "generated": true
       },
       {
@@ -9151,10 +9445,10 @@
     ],
     "lore": "In his encounter with the Dead Gods, Anti-Mage learned the value of being elusive.",
     "mc": [
-      "65",
       "60",
       "55",
-      "50"
+      "50",
+      "45"
     ],
     "cd": [
       "10.5",
@@ -9616,10 +9910,10 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": [
+          "600",
           "700",
-          "775",
-          "850",
-          "925"
+          "800",
+          "900"
         ],
         "generated": true
       },
@@ -9941,9 +10235,9 @@
     ],
     "lore": "Atropos finds no greater pleasure than to harvest the fear he creates.",
     "mc": [
+      "105",
       "120",
-      "130",
-      "140",
+      "135",
       "150"
     ],
     "cd": [
@@ -10126,7 +10420,10 @@
   "bane_ichor_of_nyctasha": {
     "dname": "Ichor of Nyctasha",
     "is_innate": true,
-    "behavior": "Passive",
+    "behavior": [
+      "Passive",
+      "Hidden"
+    ],
     "dmg_type": "Pure",
     "desc": "Every time Bane kills an enemy hero or they die under the effect of Bane's debuff, they receive a Terror for the rest of the game that decreases their status resistance to Bane's subsequent debuffs.",
     "attrib": [
@@ -10175,10 +10472,10 @@
         "key": "attack_speed",
         "header": "ATTACK SPEED:",
         "value": [
-          "60",
-          "90",
-          "120",
-          "150"
+          "55",
+          "80",
+          "105",
+          "130"
         ]
       },
       {
@@ -10255,10 +10552,10 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "105",
-          "175",
-          "245",
-          "315"
+          "100",
+          "155",
+          "210",
+          "265"
         ]
       },
       {
@@ -10464,9 +10761,9 @@
     ],
     "lore": "When the Bloodseeker hunts you, injuries become fatalities.",
     "mc": [
-      "100",
-      "150",
-      "200"
+      "125",
+      "175",
+      "225"
     ],
     "cd": [
       "75",
@@ -11030,7 +11327,7 @@
     ],
     "lore": "So convincing that some allies have spent minutes talking to the clone before they realized she wasn't speaking back.",
     "mc": "150",
-    "cd": "10",
+    "cd": "12",
     "img": "/apps/dota2/images/dota_react/abilities/crystal_maiden_crystal_clone.png"
   },
   "crystal_maiden_glacial_guard": {
@@ -11089,10 +11386,10 @@
         "key": "damage",
         "header": "BONUS DAMAGE:",
         "value": [
-          "10",
-          "15",
-          "20",
-          "25"
+          "12",
+          "18",
+          "24",
+          "30"
         ]
       },
       {
@@ -11339,7 +11636,7 @@
       }
     ],
     "lore": "Traxex is rather fond of the tranquility of physical combat, calling on her Drow heritage to end the incantations of opposing magi.",
-    "mc": "70",
+    "mc": "55",
     "cd": [
       "19",
       "17",
@@ -11387,7 +11684,7 @@
       "Hero",
       "Basic"
     ],
-    "desc": "Drow's experiences in battle grant her a chance to launch arrows with incredible accuracy and effectiveness. Pierces through the enemy's defenses, ignoring their base armor. This ability is disabled if there is an enemy hero within 325 range.",
+    "desc": "Drow's experiences in battle grant her a chance to launch arrows with incredible accuracy and effectiveness. Pierces through the enemy's defenses, ignoring their base armor. This ability is disabled if there is an enemy hero within 300 range.",
     "attrib": [
       {
         "key": "chance",
@@ -11410,7 +11707,7 @@
       {
         "key": "disable_range",
         "header": "DISABLE RANGE:",
-        "value": "325",
+        "value": "300",
         "generated": true
       }
     ],
@@ -11567,7 +11864,7 @@
     "dname": "-18% Frost Arrows Mana Cost"
   },
   "special_bonus_unique_drow_ranger_8": {
-    "dname": "+1 Multishot Wave"
+    "dname": "+2 Multishot Waves"
   },
   "special_bonus_unique_drow_ranger_gust_selfmovespeed": {
     "dname": "50% Gust Self Movement Speed"
@@ -11974,10 +12271,10 @@
         "key": "blade_dance_crit_mult",
         "header": "CRITICAL DAMAGE:",
         "value": [
-          "130%",
-          "150%",
-          "170%",
-          "190%"
+          "140%",
+          "160%",
+          "180%",
+          "200%"
         ]
       },
       {
@@ -12005,10 +12302,10 @@
         "key": "blade_fury_damage",
         "header": "DAMAGE PER SECOND:",
         "value": [
-          "80",
-          "110",
-          "140",
-          "170"
+          "85",
+          "115",
+          "145",
+          "175"
         ]
       },
       {
@@ -12079,11 +12376,11 @@
       }
     ],
     "lore": "Yurnero's renowned katana techniques are feared by warriors and sorcerors alike.",
-    "mc": "120",
+    "mc": "110",
     "cd": [
-      "36",
       "30",
-      "24",
+      "26",
+      "22",
       "18"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/juggernaut_blade_fury.png"
@@ -12307,7 +12604,7 @@
       },
       {
         "key": "agi_bonus_pct_per_stack",
-        "header": "BASE AGILITY PCT PER STACK:",
+        "header": "BASE AGILITY PER STACK:",
         "value": "2.5%"
       },
       {
@@ -12539,9 +12836,9 @@
     "desc": "Fires a long-range arrow with deadly precision, which stuns and damages the first enemy unit it strikes. The stun duration ranges from 0.01 to 2.6 seconds, with bonus damage up to 180 added, based on the distance the arrow travels to its target. Instantly kills the first non-ancient creep it hits.",
     "dmg": [
       "60",
-      "150",
-      "240",
-      "330"
+      "160",
+      "260",
+      "360"
     ],
     "attrib": [
       {
@@ -12868,7 +13165,7 @@
       {
         "key": "secondary_starfall_damage_percent",
         "header": "SECOND METEOR DAMAGE:",
-        "value": "70%"
+        "value": "80%"
       },
       {
         "key": "starfall_radius",
@@ -12962,7 +13259,7 @@
       "Hero",
       "Basic"
     ],
-    "desc": "When a charge is available, Mirana's next attack will deal bonus magic damage.\n\nGains a charge every 7 hero levels.",
+    "desc": "When a charge is available, Mirana's next attack will deal bonus magic damage.",
     "attrib": [
       {
         "key": "abilitycharges",
@@ -12971,10 +13268,9 @@
         "generated": true
       },
       {
-        "key": "levels_per_quiver_tooltip",
-        "header": "LEVELS PER QUIVER TOOLTIP:",
-        "value": "7",
-        "generated": true
+        "key": "bonus_damage",
+        "header": "BONUS DAMAGE:",
+        "value": "5"
       },
       {
         "key": "quiver_restore",
@@ -12998,7 +13294,7 @@
     "img": "/apps/dota2/images/dota_react/abilities/mirana_celestial_quiver.png"
   },
   "special_bonus_unique_mirana_1": {
-    "dname": "+90 Leap Attack Speed"
+    "dname": "+100 Leap Attack Speed"
   },
   "special_bonus_unique_mirana_2": {
     "dname": "+2 Multishot Sacred Arrows"
@@ -13108,7 +13404,7 @@
       }
     ],
     "lore": "Nevermore's trademark for harvesting souls.",
-    "mc": "80",
+    "mc": "75",
     "cd": "9",
     "img": "/apps/dota2/images/dota_react/abilities/nevermore_shadowraze1.png"
   },
@@ -13199,7 +13495,7 @@
       }
     ],
     "lore": "Nevermore's trademark for harvesting souls.",
-    "mc": "80",
+    "mc": "75",
     "cd": "9",
     "img": "/apps/dota2/images/dota_react/abilities/nevermore_shadowraze2.png"
   },
@@ -13290,7 +13586,7 @@
       }
     ],
     "lore": "Nevermore's trademark for harvesting souls.",
-    "mc": "80",
+    "mc": "75",
     "cd": "9",
     "img": "/apps/dota2/images/dota_react/abilities/nevermore_shadowraze3.png"
   },
@@ -13364,10 +13660,10 @@
         "key": "presence_armor_reduction",
         "header": "ARMOR REDUCTION:",
         "value": [
-          "-3",
+          "-2.5",
           "-4",
-          "-5",
-          "-6"
+          "-5.5",
+          "-7"
         ]
       },
       {
@@ -13964,7 +14260,7 @@
     "dispellable": "No",
     "target_team": [],
     "target_type": [],
-    "desc": "Morphling changes his form to match the targeted enemy, gaining their basic abilities. Can be toggled for the duration of the ability.",
+    "desc": "Morphling changes his form to match the targeted enemy, gaining their basic abilities and changing his primary attribute based on his target. Can be toggled for the duration of the ability.",
     "attrib": [
       {
         "key": "duration",
@@ -14135,7 +14431,7 @@
       {
         "key": "attack_range_per_agi",
         "header": "AGILITY TO ATTACK RANGE:",
-        "value": "20%"
+        "value": "25%"
       },
       {
         "key": "move_speed_per_agi",
@@ -14145,23 +14441,23 @@
       {
         "key": "cast_range_per_str",
         "header": "STRENGTH TO CAST RANGE:",
-        "value": "20%"
+        "value": "25%"
       },
       {
         "key": "slow_resist_per_str",
         "header": "STRENGTH TO SLOW RESISTANCE:",
-        "value": "20%"
+        "value": "25%"
       },
       {
         "key": "model_scale_min",
         "header": "MODEL SCALE MIN:",
-        "value": "-20",
+        "value": "0",
         "generated": true
       },
       {
         "key": "model_scale_max",
         "header": "MODEL SCALE MAX:",
-        "value": "40",
+        "value": "20",
         "generated": true
       }
     ],
@@ -14199,7 +14495,7 @@
       {
         "key": "duration",
         "header": "SLOW DURATION:",
-        "value": "3.75"
+        "value": "3"
       },
       {
         "key": "movement_speed_pct",
@@ -14559,10 +14855,10 @@
         "key": "damage",
         "header": "IMPACT DAMAGE:",
         "value": [
-          "75",
-          "150",
-          "225",
-          "300"
+          "70",
+          "140",
+          "210",
+          "280"
         ]
       },
       {
@@ -15207,12 +15503,12 @@
       "Hidden",
       "Passive"
     ],
-    "desc": "Pudge's skin thickens permanently every time he kills an enemy Hero, gaining 1.6 bonus Strength for each stack.",
+    "desc": "Pudge's skin thickens permanently every time he kills an enemy Hero, gaining 2 bonus Strength for each stack.",
     "attrib": [
       {
         "key": "flesh_heap_strength_buff_amount",
         "header": "FLESH HEAP STRENGTH BUFF AMOUNT:",
-        "value": "1.6",
+        "value": "2",
         "generated": true
       },
       {
@@ -15812,7 +16108,7 @@
       {
         "key": "epicenter_radius_base",
         "header": "BASE RADIUS:",
-        "value": "500"
+        "value": "450"
       },
       {
         "key": "epicenter_radius_increment",
@@ -15832,9 +16128,9 @@
         "key": "epicenter_slow_as",
         "header": "ATTACK SLOW:",
         "value": [
-          "-50",
-          "-55",
-          "-60"
+          "-30",
+          "-40",
+          "-50"
         ]
       },
       {
@@ -15939,12 +16235,7 @@
       {
         "key": "debuff_duration",
         "header": "SLOW DURATION:",
-        "value": [
-          "4",
-          "5",
-          "6",
-          "7"
-        ]
+        "value": "5"
       },
       {
         "key": "strike_slow",
@@ -16330,7 +16621,7 @@
     "is_innate": true,
     "behavior": "Passive",
     "dispellable": "No",
-    "desc": "Storm Spirit gains a charge of 0.2 mana regeneration per kill. Loses 2 charges per death. Additionally every time he gains a charge he also gains 0.1 Mana Regen permanently.",
+    "desc": "Storm Spirit gains a charge of 0.2 mana regeneration per kill, and a charge every 3 levels. Loses 2 charges per death. Additionally every time he gains a charge he also gains 0.1 Mana Regen permanently.",
     "attrib": [
       {
         "key": "perma_mp_per_kill",
@@ -16353,6 +16644,12 @@
         "key": "charges_per_death",
         "header": "CHARGES PER DEATH:",
         "value": "2",
+        "generated": true
+      },
+      {
+        "key": "level_divisor",
+        "header": "LEVEL DIVISOR:",
+        "value": "3",
         "generated": true
       }
     ],
@@ -16397,9 +16694,9 @@
         "header": "STUN DURATION:",
         "value": [
           "1",
-          "1.2",
-          "1.4",
-          "1.6"
+          "1.25",
+          "1.5",
+          "1.75"
         ]
       },
       {
@@ -16438,12 +16735,7 @@
       }
     ],
     "lore": "The Rogue Knight's iron gauntlet, taken from the school of his father, strikes his foes to their core.",
-    "mc": [
-      "110",
-      "115",
-      "120",
-      "125"
-    ],
+    "mc": "110",
     "cd": [
       "21",
       "18",
@@ -16591,7 +16883,7 @@
       {
         "key": "bonus_slow_resistance",
         "header": "SLOW RESISTANCE:",
-        "value": "30%"
+        "value": "40%"
       },
       {
         "key": "abilityduration",
@@ -16753,7 +17045,7 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "1.25",
+        "value": "1.1",
         "generated": true
       },
       {
@@ -16866,10 +17158,10 @@
         "key": "attack_count",
         "header": "NUMBER OF ATTACKS:",
         "value": [
-          "4",
           "5",
           "6",
-          "7"
+          "7",
+          "8"
         ]
       },
       {
@@ -16951,10 +17243,10 @@
       "25"
     ],
     "cd": [
-      "15",
-      "12",
-      "9",
-      "6"
+      "16",
+      "13",
+      "10",
+      "7"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/tiny_tree_grab.png"
   },
@@ -16983,7 +17275,7 @@
       {
         "key": "range",
         "header": "CAST RANGE:",
-        "value": "1200"
+        "value": "1000"
       },
       {
         "key": "bonus_damage",
@@ -17013,7 +17305,7 @@
       {
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
-        "value": "1200",
+        "value": "1000",
         "generated": true
       },
       {
@@ -17084,7 +17376,7 @@
       }
     ],
     "lore": "Sticks thrown from stones are like to shatter many bones.",
-    "mc": "200",
+    "mc": "150",
     "cd": "17",
     "img": "/apps/dota2/images/dota_react/abilities/tiny_tree_channel.png"
   },
@@ -17107,9 +17399,9 @@
         "key": "bonus_damage",
         "header": "BONUS DAMAGE:",
         "value": [
-          "55",
-          "110",
-          "165"
+          "60",
+          "120",
+          "180"
         ]
       },
       {
@@ -17122,8 +17414,8 @@
         "header": "TOSS BONUS DAMAGE:",
         "value": [
           "50",
-          "175",
-          "300"
+          "200",
+          "350"
         ]
       },
       {
@@ -17131,8 +17423,8 @@
         "header": "MOVEMENT SPEED BONUS:",
         "value": [
           "10",
-          "15",
-          "20"
+          "20",
+          "30"
         ]
       }
     ],
@@ -17172,7 +17464,7 @@
       {
         "key": "str_to_slow_resist_pct",
         "header": "STRENGTH TO SLOW RESIST:",
-        "value": "20%"
+        "value": "15%"
       },
       {
         "key": "str_to_status_resist_pct",
@@ -17215,9 +17507,9 @@
         "key": "magic_missile_damage",
         "header": "DAMAGE:",
         "value": [
-          "85",
-          "170",
-          "255",
+          "100",
+          "180",
+          "260",
           "340"
         ]
       },
@@ -17266,7 +17558,7 @@
     "behavior": "Passive",
     "bkbpierce": "Yes",
     "target_team": "Friendly",
-    "desc": "Vengeful Spirit's presence increases the damage of nearby friendly heroes. Vengeful Spirit herself receives 20% extra bonus.",
+    "desc": "Vengeful Spirit's presence increases the damage of nearby friendly heroes. Vengeful Spirit herself receives 25% extra bonus.",
     "attrib": [
       {
         "key": "bonus_base_damage",
@@ -17281,7 +17573,7 @@
       {
         "key": "self_multiplier",
         "header": "SELF MULTIPLIER:",
-        "value": "20%"
+        "value": "25%"
       },
       {
         "key": "aura_radius",
@@ -17532,7 +17824,7 @@
     ],
     "lore": "At last Lyralei has learned to call upon the might of her true birthright.",
     "mc": "125",
-    "cd": "30",
+    "cd": "25",
     "img": "/apps/dota2/images/dota_react/abilities/windrunner_gale_force.png"
   },
   "windrunner_shackleshot": {
@@ -17640,10 +17932,10 @@
         "key": "slow",
         "header": "SLOW:",
         "value": [
-          "20%",
-          "25%",
-          "30%",
-          "35%"
+          "22%",
+          "28%",
+          "34%",
+          "40%"
         ]
       },
       {
@@ -17764,16 +18056,6 @@
         "generated": true
       },
       {
-        "key": "duration",
-        "header": "DURATION:",
-        "value": [
-          "3",
-          "4",
-          "5",
-          "6"
-        ]
-      },
-      {
         "key": "abilityduration",
         "header": "DURATION:",
         "value": [
@@ -17882,8 +18164,8 @@
       "125"
     ],
     "cd": [
-      "70",
       "50",
+      "40",
       "30"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/windrunner_focusfire.png"
@@ -17938,7 +18220,7 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "2"
+        "value": "2.5"
       },
       {
         "key": "max_movespeed",
@@ -18924,7 +19206,7 @@
         "generated": true
       }
     ],
-    "cd": "60.5",
+    "cd": "50.5",
     "img": "/apps/dota2/images/dota_react/abilities/kunkka_admirals_rum.png"
   },
   "lina_dragon_slave": {
@@ -18997,10 +19279,10 @@
     ],
     "lore": "In the scorched barren of Misrule, Lina learned to manipulate the fiery breath of the Desert Wyrm as a form of entertainment.",
     "mc": [
+      "90",
       "100",
       "110",
-      "120",
-      "130"
+      "120"
     ],
     "cd": [
       "11",
@@ -19046,9 +19328,9 @@
         "header": "DAMAGE:",
         "value": [
           "80",
-          "120",
-          "160",
-          "200"
+          "125",
+          "170",
+          "215"
         ]
       },
       {
@@ -19189,9 +19471,9 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "380",
-          "565",
-          "750"
+          "400",
+          "580",
+          "760"
         ]
       },
       {
@@ -19603,7 +19885,7 @@
       {
         "key": "mana_drain",
         "header": "MANA DRAIN PER SECOND:",
-        "value": "20%"
+        "value": "25%"
       },
       {
         "key": "damage",
@@ -20322,7 +20604,7 @@
       {
         "key": "damage_per_kill",
         "header": "DAMAGE PER KILL:",
-        "value": "30"
+        "value": "25"
       },
       {
         "key": "grace_period",
@@ -20748,24 +21030,28 @@
       {
         "key": "mega_ward_multiplier_damage",
         "header": "MEGA WARD MULTIPLIER DAMAGE:",
-        "value": "0",
+        "value": "4",
         "generated": true
       },
       {
         "key": "mega_ward_multiplier_health",
         "header": "MEGA WARD MULTIPLIER HEALTH:",
-        "value": "0",
+        "value": "4",
         "generated": true
       },
       {
         "key": "mega_ward_health_tooltip",
         "header": "MEGA WARD HEALTH:",
-        "value": "0"
+        "value": "8"
       },
       {
         "key": "mega_ward_damage_tooltip",
         "header": "MEGA WARD DAMAGE:",
-        "value": "0"
+        "value": [
+          "200",
+          "340",
+          "480"
+        ]
       },
       {
         "key": "mega_ward_model_scale_multiplier",
@@ -20960,7 +21246,7 @@
         "generated": true
       }
     ],
-    "mc": "115",
+    "mc": "140",
     "cd": "50",
     "img": "/apps/dota2/images/dota_react/abilities/shadow_shaman_urnaconda.png"
   },
@@ -21093,10 +21379,10 @@
     "lore": "As Slardar has made the transition from the Deeps, it has been necessary to use his powerful tail for sprinting instead of swimming.",
     "mc": "25",
     "cd": [
-      "29",
-      "25",
-      "21",
-      "17"
+      "33",
+      "28",
+      "23",
+      "18"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/slardar_sprint.png"
   },
@@ -21194,7 +21480,12 @@
     ],
     "lore": "A swift crush of might and water breaks even the toughest of defenses.",
     "mc": "100",
-    "cd": "7",
+    "cd": [
+      "8.5",
+      "8",
+      "7.5",
+      "7"
+    ],
     "img": "/apps/dota2/images/dota_react/abilities/slardar_slithereen_crush.png"
   },
   "slardar_bash": {
@@ -21246,8 +21537,8 @@
         "key": "armor_reduction",
         "header": "ARMOR REDUCTION:",
         "value": [
-          "-10",
-          "-15",
+          "-8",
+          "-14",
           "-20"
         ]
       },
@@ -21489,6 +21780,12 @@
         "generated": true
       },
       {
+        "key": "building_pct_damage",
+        "header": "BUILDING PCT DAMAGE:",
+        "value": "0",
+        "generated": true
+      },
+      {
         "key": "additional_range",
         "header": "ADDITIONAL RANGE:",
         "value": "225",
@@ -21670,10 +21967,13 @@
     "cd": "35",
     "img": "/apps/dota2/images/dota_react/abilities/tidehunter_dead_in_the_water.png"
   },
-  "tidehunter_krill_eater": {
+  "tidehunter_leviathans_catch": {
     "dname": "Leviathan's Catch",
     "is_innate": true,
-    "behavior": "Passive",
+    "behavior": [
+      "Passive",
+      "Hidden"
+    ],
     "dispellable": "No",
     "attrib": [
       {
@@ -21733,7 +22033,7 @@
       {
         "key": "max_fish_spawn_distance",
         "header": "MAX FISH SPAWN DISTANCE:",
-        "value": "400",
+        "value": "200",
         "generated": true
       },
       {
@@ -21749,7 +22049,7 @@
         "generated": true
       }
     ],
-    "img": "/apps/dota2/images/dota_react/abilities/tidehunter_krill_eater.png"
+    "img": "/apps/dota2/images/dota_react/abilities/tidehunter_leviathans_catch.png"
   },
   "tidehunter_blubber": {
     "dname": "Blubber",
@@ -21894,12 +22194,7 @@
       {
         "key": "radius",
         "header": "RADIUS:",
-        "value": [
-          "500",
-          "550",
-          "600",
-          "650"
-        ]
+        "value": "650"
       },
       {
         "key": "heal",
@@ -22280,10 +22575,10 @@
     "lore": "Since his escape during the night of his betrayal, Riki has valued the use of a simple smoke screen to confuse his opponents.",
     "mc": "75",
     "cd": [
-      "17",
       "15",
+      "14",
       "13",
-      "11"
+      "12"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/riki_smoke_screen.png"
   },
@@ -22311,10 +22606,10 @@
         "key": "bonus_damage",
         "header": "BONUS DAMAGE:",
         "value": [
-          "15",
-          "30",
+          "25",
+          "35",
           "45",
-          "60"
+          "55"
         ]
       },
       {
@@ -22402,7 +22697,7 @@
       {
         "key": "ally_multiplier",
         "header": "ALLY MULTIPLIER:",
-        "value": "25",
+        "value": "30",
         "generated": true
       },
       {
@@ -22683,9 +22978,9 @@
         "header": "EIDOLON DAMAGE:",
         "value": [
           "16",
-          "27",
-          "38",
-          "49"
+          "28",
+          "40",
+          "52"
         ]
       },
       {
@@ -22835,10 +23130,10 @@
       "100"
     ],
     "cd": [
+      "45",
       "40",
-      "38",
-      "36",
-      "34"
+      "35",
+      "30"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/enigma_demonic_conversion.png"
   },
@@ -23027,7 +23322,7 @@
     "dname": "+10 Eidolon Attack Speed"
   },
   "special_bonus_unique_enigma_5": {
-    "dname": "+{s:bonus_radius} Event Horizon Radius"
+    "dname": "+100 Event Horizon Radius"
   },
   "special_bonus_unique_enigma_6": {
     "dname": "+50 Black Hole Damage Per Second"
@@ -23123,7 +23418,7 @@
       {
         "key": "speed_bonus",
         "header": "MOVEMENT SLOW:",
-        "value": "4%"
+        "value": "5%"
       },
       {
         "key": "vision_cone",
@@ -23791,7 +24086,7 @@
       {
         "key": "drop_knockback_distance_tinker",
         "header": "TINKER KNOCKBACK:",
-        "value": "350"
+        "value": "400"
       },
       {
         "key": "drop_count",
@@ -23846,7 +24141,7 @@
       {
         "key": "missile_speed",
         "header": "MISSILE SPEED:",
-        "value": "1200",
+        "value": "1350",
         "generated": true
       },
       {
@@ -23915,7 +24210,7 @@
       {
         "key": "activation_time",
         "header": "ACTIVATION TIME:",
-        "value": "0.3",
+        "value": "0",
         "generated": true
       }
     ],
@@ -24222,12 +24517,6 @@
         "generated": true
       },
       {
-        "key": "no_reveal",
-        "header": "NO REVEAL:",
-        "value": "0",
-        "generated": true
-      },
-      {
         "key": "attack_speed",
         "header": "ATTACK SPEED:",
         "value": "0"
@@ -24408,7 +24697,7 @@
       }
     ],
     "lore": "The Rumusque Faithful consider Necrophos to be more plague than person.",
-    "mc": "125",
+    "mc": "160",
     "cd": "19",
     "img": "/apps/dota2/images/dota_react/abilities/necrolyte_death_seeker.png"
   },
@@ -24950,9 +25239,9 @@
     "lore": "Demnok manipulates space-time, impairing entire armies.",
     "mc": "100",
     "cd": [
-      "60",
-      "50",
+      "45",
       "40",
+      "35",
       "30"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/warlock_upheaval.png"
@@ -25407,7 +25696,12 @@
       {
         "key": "duration",
         "header": "DEBUFF DURATION:",
-        "value": "12"
+        "value": [
+          "10",
+          "11",
+          "12",
+          "13"
+        ]
       },
       {
         "key": "damage_amp",
@@ -25445,12 +25739,7 @@
       }
     ],
     "lore": "While learning to maneuver in nature alone, the Beastmaster also mastered the use of a pair of tomahawks, adept at cutting down trees as well as adversaries.",
-    "mc": [
-      "50",
-      "55",
-      "60",
-      "65"
-    ],
+    "mc": "65",
     "cd": "8",
     "img": "/apps/dota2/images/dota_react/abilities/beastmaster_wild_axes.png"
   },
@@ -25484,9 +25773,9 @@
         "key": "boar_base_damage",
         "header": "BOAR BASE DAMAGE:",
         "value": [
-          "30",
-          "45",
-          "60",
+          "24",
+          "41",
+          "58",
           "75"
         ],
         "generated": true
@@ -25495,9 +25784,9 @@
         "key": "boar_total_damage_tooltip",
         "header": "BOAR ATTACK DAMAGE:",
         "value": [
-          "30",
-          "45",
-          "60",
+          "24",
+          "41",
+          "58",
           "75"
         ]
       },
@@ -26016,7 +26305,7 @@
       {
         "key": "radius",
         "header": "DAMAGE RADIUS:",
-        "value": "600"
+        "value": "525"
       },
       {
         "key": "max_stacks",
@@ -26042,7 +26331,7 @@
       {
         "key": "base_damage",
         "header": "DRUM HIT DAMAGE:",
-        "value": "80"
+        "value": "70"
       },
       {
         "key": "heal_pct",
@@ -26213,10 +26502,10 @@
       "130"
     ],
     "cd": [
-      "13",
-      "10",
+      "11",
+      "9",
       "7",
-      "4"
+      "5"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/queenofpain_shadow_strike.png"
   },
@@ -26652,7 +26941,7 @@
       {
         "key": "movement_speed",
         "header": "MOVEMENT SLOW:",
-        "value": "10%"
+        "value": "8%"
       },
       {
         "key": "hp_regen_reduction",
@@ -26882,10 +27171,10 @@
         "key": "tick_damage",
         "header": "DAMAGE PER SECOND:",
         "value": [
+          "10",
           "20",
-          "25",
           "30",
-          "35"
+          "40"
         ]
       },
       {
@@ -27280,7 +27569,7 @@
       {
         "key": "radius",
         "header": "RADIUS:",
-        "value": "775"
+        "value": "700"
       },
       {
         "key": "duration",
@@ -27604,7 +27893,7 @@
       {
         "key": "skeleton_duration",
         "header": "SKELETON DURATION:",
-        "value": "46"
+        "value": "40"
       },
       {
         "key": "max_skeleton_charges",
@@ -27776,12 +28065,7 @@
       }
     ],
     "lore": "One blow to crush a foe.",
-    "cd": [
-      "6",
-      "5.5",
-      "5",
-      "4.5"
-    ],
+    "cd": "5",
     "img": "/apps/dota2/images/dota_react/abilities/skeleton_king_mortal_strike.png"
   },
   "skeleton_king_reincarnation": {
@@ -27857,7 +28141,7 @@
       {
         "key": "vampiric_aura",
         "header": "LIFESTEAL:",
-        "value": "14%"
+        "value": "20%"
       },
       {
         "key": "duration",
@@ -28128,7 +28412,7 @@
         "generated": true
       }
     ],
-    "mc": "80",
+    "mc": "60",
     "cd": "0",
     "img": "/apps/dota2/images/dota_react/abilities/death_prophet_spirit_siphon.png"
   },
@@ -28175,13 +28459,21 @@
       {
         "key": "min_damage",
         "header": "MIN DAMAGE:",
-        "value": "62",
+        "value": [
+          "62",
+          "65",
+          "68"
+        ],
         "generated": true
       },
       {
         "key": "max_damage",
         "header": "MAX DAMAGE:",
-        "value": "67",
+        "value": [
+          "68",
+          "71",
+          "74"
+        ],
         "generated": true
       },
       {
@@ -28192,7 +28484,11 @@
       {
         "key": "average_damage",
         "header": "SPIRIT DAMAGE:",
-        "value": "64"
+        "value": [
+          "65",
+          "68",
+          "71"
+        ]
       },
       {
         "key": "ghost_spawn_rate",
@@ -28451,16 +28747,16 @@
         "key": "bonus_attack_speed",
         "header": "BONUS ATTACK SPEED:",
         "value": [
-          "100",
-          "130",
+          "80",
+          "120",
           "160",
-          "190"
+          "200"
         ]
       },
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "2.5"
+        "value": "3"
       },
       {
         "key": "abilitycastrange",
@@ -28516,7 +28812,7 @@
   "phantom_assassin_immaterial": {
     "dname": "Immaterial",
     "behavior": "Passive",
-    "desc": "Phantom Assassin focuses inward, increasing her ability to evade enemy attacks. Evasion improves with Phantom Assassin's levels. \n\nStacks diminishingly with other sources of Evasion.",
+    "desc": "Phantom Assassin focuses inward, increasing her ability to evade enemy attacks.\n\nStacks diminishingly with other sources of Evasion.",
     "attrib": [
       {
         "key": "evasion",
@@ -28620,8 +28916,8 @@
         "header": "CRITICAL DAMAGE:",
         "value": [
           "200%",
-          "300%",
-          "400%"
+          "325%",
+          "450%"
         ]
       },
       {
@@ -28836,7 +29132,7 @@
       {
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
-        "value": "150",
+        "value": "175",
         "generated": true
       },
       {
@@ -29370,7 +29666,7 @@
     "dname": "Inner Peace",
     "is_innate": true,
     "behavior": "Passive",
-    "desc": "When remaining stationary and not taking damage for 0.25s, Templar Assassin begins meditating, gaining health and mana regeneration, reaching the maximum bonus after 2.05s of meditating.",
+    "desc": "When remaining stationary and not taking damage for 0.2s, Templar Assassin begins meditating, gaining health and mana regeneration, reaching the maximum bonus after 1.85s of meditating.",
     "attrib": [
       {
         "key": "max_attack_range",
@@ -29391,13 +29687,13 @@
       {
         "key": "time_until_meditation",
         "header": "TIME UNTIL MEDITATION:",
-        "value": "0.25",
+        "value": "0.2",
         "generated": true
       },
       {
         "key": "time_until_max_bonus",
         "header": "MEDITATION TIME UNTIL MAX BONUS:",
-        "value": "2.05"
+        "value": "1.85"
       }
     ],
     "mc": "0",
@@ -29828,7 +30124,7 @@
     ],
     "lore": "It was thought that Netherdrake wings touch ground only in death, but some surmise that those who've witnessed more intentional landings merely haven't survived to tell the tale.",
     "mc": "75",
-    "cd": "20",
+    "cd": "25",
     "img": "/apps/dota2/images/dota_react/abilities/viper_nose_dive.png"
   },
   "luna_lucent_beam": {
@@ -30393,7 +30689,7 @@
       {
         "key": "aoe",
         "header": "AOE:",
-        "value": "25"
+        "value": "50"
       },
       {
         "key": "abilitycastrange",
@@ -30483,6 +30779,7 @@
     "dname": "Elder Dragon Form",
     "behavior": "No Target",
     "dmg_type": "Magical",
+    "bkbpierce": "Yes",
     "dispellable": "No",
     "desc": "Dragon Knight assumes the form of the Elder Dragon, increasing the range of his abilities, gaining bonus movement speed, and a ranged attack with various properties. The Dragon evolves per level. The bonuses are cumulative. \n\nLevel 1 Green: Grants a corrosive damage over time that can also damage buildings.\n\nLevel 2 Red: Grants splash damage to the dragon's attacks.\n\nLevel 3 Blue: Grants a debuff immunity piercing movement and attack frost slow on attack.",
     "attrib": [
@@ -30578,6 +30875,17 @@
           "0",
           "0",
           "20"
+        ],
+        "generated": true
+      },
+      {
+        "key": "flying_movement",
+        "header": "FLYING MOVEMENT:",
+        "value": [
+          "0",
+          "0",
+          "0",
+          "1"
         ],
         "generated": true
       },
@@ -30772,10 +31080,10 @@
         "key": "bonus_slow",
         "header": "BONUS SLOW PER HIT:",
         "value": [
-          "-2%",
           "-2.5%",
           "-3%",
-          "-3.5%"
+          "-3.5%",
+          "-4%"
         ]
       },
       {
@@ -31369,7 +31677,7 @@
     ],
     "bkbpierce": "Yes",
     "dispellable": "No",
-    "desc": "Supercharges Clockwerks abilities:\n\nBattery Assault: Increased radius and affects all enemies in its range.\nPower Cogs: Radius increased, and Clockwerk's armor while near Power Cogs is increased.\nRocket Flares: Increased damage, vision and slow duration, and fire additional rockets to either side of the target.\nHookshot: Stun radius and duration increased.\nJetpack Moves faster.\n\nClockwerk's movement and attack speed becomes slowed to a crawl after the duration runs out.",
+    "desc": "Supercharges Clockwerks abilities:\n\nBattery Assault: Increased radius and affects all enemies in its range.\nPower Cogs: Radius increased, and Clockwerk's armor while near Power Cogs is increased.\nRocket Flares: Increased damage, vision and slow duration, and fire additional rockets to either side of the target.\nHookshot: Stun radius and duration increased.\nJetpack: Moves faster.\n\nClockwerk's movement and attack speed becomes slowed to a crawl after the duration runs out.",
     "attrib": [
       {
         "key": "buff_duration",
@@ -31552,20 +31860,20 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "50",
-          "125",
-          "200",
-          "275"
+          "55",
+          "110",
+          "165",
+          "220"
         ]
       },
       {
         "key": "mana_burn",
         "header": "MANA BURN:",
         "value": [
-          "35",
-          "75",
-          "115",
-          "155"
+          "40",
+          "80",
+          "120",
+          "160"
         ]
       },
       {
@@ -31664,12 +31972,7 @@
       }
     ],
     "lore": "One of Clockwerk's inventions of which he is most proud is the power cog - though it is sometimes despised by his allies.",
-    "mc": [
-      "60",
-      "65",
-      "70",
-      "75"
-    ],
+    "mc": "75",
     "cd": [
       "21",
       "19",
@@ -32043,10 +32346,10 @@
         "key": "damage",
         "header": "DAMAGE PER EXPLOSION:",
         "value": [
-          "10",
-          "18",
-          "26",
-          "34"
+          "9",
+          "16",
+          "23",
+          "30"
         ]
       },
       {
@@ -32197,7 +32500,7 @@
       {
         "key": "slow",
         "header": "SLOW:",
-        "value": "30%"
+        "value": "40%"
       },
       {
         "key": "radius",
@@ -32227,9 +32530,9 @@
         "key": "mana_cost_per_second",
         "header": "MANA/SEC:",
         "value": [
-          "25",
-          "45",
-          "65"
+          "20",
+          "40",
+          "60"
         ]
       },
       {
@@ -32522,10 +32825,10 @@
         "key": "treant_bonus_hero_damage",
         "header": "TREANT BONUS HERO DAMAGE:",
         "value": [
-          "4",
-          "8",
-          "12",
-          "16"
+          "6",
+          "10",
+          "14",
+          "18"
         ]
       },
       {
@@ -32586,7 +32889,12 @@
       }
     ],
     "lore": "Verodicia bestowed the Prophet with the ability to summon the Treant Guard, a mythical sentient army of the wild.",
-    "mc": "100",
+    "mc": [
+      "85",
+      "90",
+      "95",
+      "100"
+    ],
     "cd": [
       "45",
       "40",
@@ -32618,9 +32926,9 @@
         "key": "damage",
         "header": "BASE DAMAGE:",
         "value": [
-          "90",
-          "130",
-          "170"
+          "100",
+          "140",
+          "180"
         ]
       },
       {
@@ -32920,7 +33228,7 @@
       "Hidden"
     ],
     "dispellable": "No",
-    "desc": "Nature's Prophet gains 2% bonus damage for each nearby tree. Treants also provide this bonus with multiplied values and with larger radius. Treants also possess this ability.",
+    "desc": "Nature's Prophet gains 2% bonus damage for each nearby tree. Treants also provide this bonus with multiplied values regardless of proximity. Treants also possess this ability.",
     "attrib": [
       {
         "key": "damage_per_tree_pct",
@@ -32937,11 +33245,6 @@
         "key": "multiplier",
         "header": "TREANT MULTIPLIER:",
         "value": "2"
-      },
-      {
-        "key": "radius_treant",
-        "header": "TREANT RADIUS:",
-        "value": "1200"
       }
     ],
     "img": "/apps/dota2/images/dota_react/abilities/furion_spirit_of_the_forest.png"
@@ -33040,7 +33343,7 @@
     "dname": "Removed Teleportation Cooldown"
   },
   "special_bonus_unique_furion_4": {
-    "dname": "+170 Sprout Damage"
+    "dname": "+240 Sprout Damage"
   },
   "special_bonus_unique_furion_5": {
     "dname": "+25 Wrath of Nature Base Damage"
@@ -33049,7 +33352,7 @@
     "dname": "-10s Nature's Call Cooldown"
   },
   "special_bonus_unique_furion_7": {
-    "dname": "-15s Wrath of Nature Cooldown"
+    "dname": "-20s Wrath of Nature Cooldown"
   },
   "special_bonus_unique_furion_teleportation_barrier": {
     "dname": "+100 Teleportation Barrier"
@@ -33095,10 +33398,10 @@
         "key": "movespeed_bonus",
         "header": "MOVESPEED BONUS:",
         "value": [
+          "6%",
           "9%",
           "12%",
-          "15%",
-          "18%"
+          "15%"
         ]
       },
       {
@@ -33228,12 +33531,7 @@
       {
         "key": "bonus_hp_per_hero",
         "header": "MAX HP PER HERO KILL:",
-        "value": [
-          "10",
-          "15",
-          "20",
-          "25"
-        ]
+        "value": "10"
       },
       {
         "key": "bonus_hp_per_creep",
@@ -34480,7 +34778,7 @@
       }
     ],
     "lore": "Sutherex' bond of life and death has become a part of Clinkz, and his old bones are refreshed with repetition of the pact on lesser beings.",
-    "mc": "60",
+    "mc": "50",
     "cd": "0",
     "img": "/apps/dota2/images/dota_react/abilities/clinkz_death_pact.png"
   },
@@ -34705,7 +35003,7 @@
       "Hero",
       "Basic"
     ],
-    "desc": "Omniknight imbues his hammer with holy power, causing his attack to have increased range, deal pure damage based on a percentage of his base damage and slow his target for a short duration.\n\n Omniknight heals for 30% of the damage dealt over 5s.",
+    "desc": "Omniknight imbues his hammer with holy power, causing his attack to have increased range, deal pure damage based on a percentage of his base damage and slow his target for a short duration.\n\n Omniknight heals for 35% of the damage dealt over 5s.",
     "dmg": "0",
     "attrib": [
       {
@@ -34722,16 +35020,16 @@
         "key": "bonus_damage",
         "header": "DAMAGE:",
         "value": [
-          "20",
-          "40",
-          "60",
-          "80"
+          "25",
+          "45",
+          "65",
+          "85"
         ]
       },
       {
         "key": "heal_pct",
         "header": "HEAL PCT:",
-        "value": "30",
+        "value": "35",
         "generated": true
       },
       {
@@ -35081,9 +35379,9 @@
     ],
     "cd": [
       "40",
-      "36",
-      "32",
-      "28"
+      "35",
+      "30",
+      "25"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/omniknight_martyr.png"
   },
@@ -35104,8 +35402,8 @@
         "header": "DURATION:",
         "value": [
           "4",
-          "4.5",
-          "5"
+          "4.75",
+          "5.5"
         ]
       },
       {
@@ -35884,10 +36182,10 @@
         "key": "burn_damage",
         "header": "BURN DAMAGE:",
         "value": [
-          "5",
-          "10",
-          "15",
-          "20"
+          "4",
+          "8",
+          "12",
+          "16"
         ]
       },
       {
@@ -36585,7 +36883,7 @@
       {
         "key": "tooltip_spiderling_hp",
         "header": "SPIDERLINGS HP:",
-        "value": "300"
+        "value": "325"
       },
       {
         "key": "slow_duration",
@@ -36999,7 +37297,7 @@
       {
         "key": "aura_radius",
         "header": "SPIDERLING RADIUS:",
-        "value": "800"
+        "value": "1200"
       },
       {
         "key": "abilitycastpoint",
@@ -37062,7 +37360,7 @@
       }
     ],
     "lore": "The slightest tremor of her web is all Arachnia needs to find her prey.",
-    "mc": "100",
+    "mc": "70",
     "img": "/apps/dota2/images/dota_react/abilities/broodmother_sticky_snare.png"
   },
   "broodmother_spin_web_destroy": {
@@ -37165,9 +37463,9 @@
     "lore": "While the shuriken may be small, Gondar's precise aim can cause critical damage.",
     "mc": [
       "75",
-      "80",
       "85",
-      "90"
+      "95",
+      "105"
     ],
     "cd": "5",
     "img": "/apps/dota2/images/dota_react/abilities/bounty_hunter_shuriken_toss.png"
@@ -37280,9 +37578,9 @@
         "key": "bonus_move_speed_pct",
         "header": "BONUS SPEED:",
         "value": [
-          "8%",
-          "12%",
-          "16%",
+          "11%",
+          "14%",
+          "17%",
           "20%"
         ]
       },
@@ -37410,7 +37708,7 @@
       }
     ],
     "lore": "Using his elevated senses of sight and smell, Gondar's hits have quite a good chance of success.",
-    "mc": "60",
+    "mc": "50",
     "cd": [
       "6",
       "5",
@@ -37466,12 +37764,12 @@
     "dname": "Big Game Hunter",
     "is_innate": true,
     "behavior": "Passive",
-    "desc": "Bounty Hunter receives 15% more kill and assist gold if the dying enemy hero is Big Game. An enemy hero is considered Big Game if they are one of the top 3 net worth heroes on the enemy team.",
+    "desc": "Bounty Hunter receives 20% more kill and assist gold if the dying enemy hero is Big Game. An enemy hero is considered Big Game if they are one of the top 3 net worth heroes on the enemy team.",
     "attrib": [
       {
         "key": "kill_assist_gold_bonus_percent",
         "header": "KILL ASSIST GOLD BONUS PERCENT:",
-        "value": "15",
+        "value": "20",
         "generated": true
       }
     ],
@@ -37562,7 +37860,12 @@
       }
     ],
     "lore": "Skitskurr opens a gap in the space time fabric, allowing young Weavers to slip through and aid him in combat.",
-    "mc": "110",
+    "mc": [
+      "110",
+      "105",
+      "100",
+      "95"
+    ],
     "cd": [
       "44",
       "36",
@@ -37821,7 +38124,7 @@
       {
         "key": "slow_duration",
         "header": "SLOW DURATION:",
-        "value": "0.2"
+        "value": "0.4"
       },
       {
         "key": "slow_percent",
@@ -37931,7 +38234,12 @@
       "165",
       "180"
     ],
-    "cd": "10",
+    "cd": [
+      "12",
+      "11",
+      "10",
+      "9"
+    ],
     "img": "/apps/dota2/images/dota_react/abilities/jakiro_dual_breath.png"
   },
   "jakiro_ice_path": {
@@ -38040,7 +38348,8 @@
     "behavior": [
       "Unit Target",
       "Autocast",
-      "Attack Modifier"
+      "Attack Modifier",
+      "AOE"
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
@@ -38072,10 +38381,10 @@
         "key": "damage",
         "header": "BURN DAMAGE:",
         "value": [
-          "15",
-          "25",
-          "35",
-          "45"
+          "12",
+          "24",
+          "36",
+          "48"
         ]
       },
       {
@@ -38323,9 +38632,9 @@
     ],
     "lore": "Ice and fire combine to rip the battlefield to shreds with extreme temperatures.",
     "mc": [
-      "300",
-      "400",
-      "500"
+      "225",
+      "325",
+      "425"
     ],
     "cd": [
       "90",
@@ -38686,10 +38995,10 @@
         "key": "damage_per_second",
         "header": "DAMAGE PER SECOND:",
         "value": [
-          "25",
-          "50",
-          "75",
-          "100"
+          "20",
+          "40",
+          "60",
+          "80"
         ]
       },
       {
@@ -38734,9 +39043,9 @@
     "lore": "When an enemy escapes into the Yama Raskav Jungle, most would cut through the brush to find the fugitive.  Batrider just chooses to destroy the jungle along with his foes.",
     "mc": "100",
     "cd": [
-      "45",
-      "40",
-      "35",
+      "48",
+      "42",
+      "36",
       "30"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/batrider_firefly.png"
@@ -38779,9 +39088,9 @@
         "key": "damage",
         "header": "TOTAL DAMAGE:",
         "value": [
-          "200",
-          "350",
-          "500"
+          "125",
+          "250",
+          "375"
         ]
       },
       {
@@ -38835,7 +39144,7 @@
     "dname": "Attacks apply 1 Stack of Sticky Napalm"
   },
   "special_bonus_unique_batrider_7": {
-    "dname": "+0.5% Sticky Napalm Movement Slow"
+    "dname": "+0.75% Sticky Napalm Movement Slow"
   },
   "special_bonus_unique_batrider_smoldering_resin_ticks": {
     "dname": "+1s Smoldering Resin Duration"
@@ -38894,9 +39203,9 @@
         "header": "DAMAGE:",
         "value": [
           "50",
-          "75",
           "100",
-          "125"
+          "150",
+          "200"
         ]
       },
       {
@@ -39166,10 +39475,10 @@
         "key": "damage_bonus",
         "header": "BONUS DAMAGE:",
         "value": [
-          "0%",
-          "6%",
-          "12%",
-          "18%"
+          "5%",
+          "10%",
+          "15%",
+          "20%"
         ]
       },
       {
@@ -39194,6 +39503,12 @@
         "key": "unsummon_time",
         "header": "UNSUMMON TIME:",
         "value": "3",
+        "generated": true
+      },
+      {
+        "key": "unsummon_cooldown_reduction",
+        "header": "UNSUMMON COOLDOWN REDUCTION:",
+        "value": "12",
         "generated": true
       },
       {
@@ -39378,20 +39693,20 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "70",
+          "80",
           "120",
-          "170",
-          "220"
+          "160",
+          "200"
         ]
       },
       {
         "key": "bonus_movespeed",
         "header": "MOVEMENT SPEED CHANGE:",
         "value": [
-          "10%",
           "14%",
+          "16%",
           "18%",
-          "22%"
+          "20%"
         ]
       },
       {
@@ -39511,10 +39826,10 @@
         "key": "damage_reflection_pct",
         "header": "DAMAGE REFLECTED:",
         "value": [
-          "8%",
+          "9%",
           "12%",
-          "16%",
-          "20%"
+          "15%",
+          "18%"
         ]
       },
       {
@@ -39525,7 +39840,7 @@
       {
         "key": "max_radius",
         "header": "MAX RADIUS:",
-        "value": "800"
+        "value": "700"
       },
       {
         "key": "activation_cooldown",
@@ -39642,8 +39957,8 @@
     "lore": "At the height of combat, Mercurial's physical manifestation shatters, and the shadowy pieces haunt those who still cling to life.",
     "mc": [
       "125",
-      "150",
-      "175"
+      "175",
+      "225"
     ],
     "cd": [
       "160",
@@ -39666,12 +39981,7 @@
       {
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
-        "value": [
-          "825",
-          "950",
-          "1075",
-          "1200"
-        ],
+        "value": "1000",
         "generated": true
       },
       {
@@ -39687,23 +39997,13 @@
       {
         "key": "illusion_damage_incoming",
         "header": "ILLUSION DAMAGE INCOMING:",
-        "value": [
-          "100",
-          "85",
-          "70",
-          "55"
-        ],
+        "value": "75",
         "generated": true
       },
       {
         "key": "tooltip_illusion_total_damage_incoming",
         "header": "ILLUSION DAMAGE TAKEN:",
-        "value": [
-          "200%",
-          "185%",
-          "170%",
-          "155%"
-        ]
+        "value": "175%"
       },
       {
         "key": "illusion_outgoing_damage",
@@ -39918,12 +40218,12 @@
       "Hidden"
     ],
     "dmg_type": [],
-    "desc": "Doom's attacks curse enemy heroes. After 2.5s, the cursed hero bursts with a pillar of fire, damaging itself and all units in a 66 AoE for 15% of the damage taken from Doom during the curse. The damage and radius of the curse is 66% stronger if the enemy's level is a multiple of 6.",
+    "desc": "Doom's attacks curse enemy heroes. After 2.5s, the cursed hero bursts with a pillar of fire, damaging itself and all units in a 66 AoE for 10% of the damage taken from Doom during the curse. The damage and radius of the curse is 66% stronger if the enemy's level is a multiple of 6.",
     "attrib": [
       {
         "key": "bonus_damage_pct_base",
         "header": "BONUS DAMAGE PCT BASE:",
-        "value": "15",
+        "value": "10",
         "generated": true
       },
       {
@@ -39966,20 +40266,15 @@
         "header": "DAMAGE:",
         "value": [
           "20",
-          "35",
-          "50",
-          "65"
+          "30",
+          "40",
+          "50"
         ]
       },
       {
         "key": "bonus_health_regen",
         "header": "BONUS HP REGEN:",
-        "value": [
-          "7",
-          "8",
-          "9",
-          "10"
-        ]
+        "value": "6.66"
       },
       {
         "key": "radius",
@@ -40136,8 +40431,8 @@
         "key": "damage",
         "header": "DAMAGE PER SECOND:",
         "value": [
-          "25",
-          "45",
+          "22",
+          "44",
           "66"
         ]
       },
@@ -40258,10 +40553,10 @@
         "key": "damage_per_second",
         "header": "DAMAGE PER SECOND:",
         "value": [
-          "20",
-          "40",
-          "60",
-          "80"
+          "25",
+          "45",
+          "65",
+          "85"
         ]
       },
       {
@@ -40462,10 +40757,10 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "30",
-          "60",
-          "90",
-          "120"
+          "35",
+          "65",
+          "95",
+          "125"
         ]
       },
       {
@@ -40503,10 +40798,10 @@
     "lore": "The Ancient Apparition's eternal knowledge brings a frigid enchantment to his attacks.",
     "mc": "35",
     "cd": [
-      "12",
-      "9",
-      "6",
-      "3"
+      "10",
+      "7.5",
+      "5",
+      "2.5"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/ancient_apparition_chilling_touch.png"
   },
@@ -40529,7 +40824,7 @@
       {
         "key": "radius_min",
         "header": "RADIUS MIN:",
-        "value": "275",
+        "value": "300",
         "generated": true
       },
       {
@@ -40547,7 +40842,7 @@
       {
         "key": "path_radius",
         "header": "PATH RADIUS:",
-        "value": "275"
+        "value": "300"
       },
       {
         "key": "frostbite_duration",
@@ -40663,12 +40958,12 @@
       {
         "key": "str_reduction",
         "header": "STRENGTH REDUCTION:",
-        "value": ".1"
+        "value": ".2"
       },
       {
         "key": "tooltip_scepter_bonus",
         "header": "TOOLTIP SCEPTER BONUS:",
-        "value": "0.3",
+        "value": "0.8",
         "generated": true
       },
       {
@@ -40737,7 +41032,7 @@
     "dname": "450 AoE Cold Feet"
   },
   "special_bonus_unique_ancient_apparition_2": {
-    "dname": "+80 Chilling Touch Damage"
+    "dname": "+100 Chilling Touch Damage"
   },
   "special_bonus_unique_ancient_apparition_3": {
     "dname": "-2s Ice Vortex Cooldown"
@@ -41157,10 +41452,10 @@
     ],
     "lore": "Barathrum erupts from the darkness with unwieldy force.",
     "mc": [
+      "80",
       "90",
       "100",
-      "110",
-      "120"
+      "110"
     ],
     "cd": [
       "22",
@@ -41383,12 +41678,6 @@
         "key": "knockback_height",
         "header": "KNOCKBACK HEIGHT:",
         "value": "50",
-        "generated": true
-      },
-      {
-        "key": "projectile_body_vision",
-        "header": "PROJECTILE BODY VISION:",
-        "value": "175",
         "generated": true
       },
       {
@@ -41804,7 +42093,7 @@
       {
         "key": "bonus_night_vision",
         "header": "BONUS NIGHT VISION:",
-        "value": "200"
+        "value": "0"
       },
       {
         "key": "abilityduration",
@@ -41826,12 +42115,7 @@
       "70",
       "80"
     ],
-    "cd": [
-      "26",
-      "24",
-      "22",
-      "20"
-    ],
+    "cd": "25",
     "img": "/apps/dota2/images/dota_react/abilities/gyrocopter_flak_cannon.png"
   },
   "gyrocopter_call_down": {
@@ -41859,7 +42143,7 @@
       {
         "key": "slow",
         "header": "MISSILE SLOW:",
-        "value": "50%"
+        "value": "60%"
       },
       {
         "key": "damage",
@@ -41929,9 +42213,9 @@
       "250"
     ],
     "cd": [
-      "90",
       "75",
-      "60"
+      "65",
+      "55"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/gyrocopter_call_down.png"
   },
@@ -41993,7 +42277,7 @@
       {
         "key": "bonus_movespeed_duration",
         "header": "DURATION:",
-        "value": "3.9"
+        "value": "4.9"
       },
       {
         "key": "bonus_movement_speed_per_hit",
@@ -42145,12 +42429,7 @@
     ],
     "lore": "Using traditional Alchemy from the Darkbrew family, Razzil concocts an acid that dissolves even the toughest metals.",
     "mc": "120",
-    "cd": [
-      "22",
-      "21",
-      "20",
-      "19"
-    ],
+    "cd": "21",
     "img": "/apps/dota2/images/dota_react/abilities/alchemist_acid_spray.png"
   },
   "alchemist_unstable_concoction": {
@@ -42367,7 +42646,7 @@
       {
         "key": "bonus_gold_per_scepter",
         "header": "BONUS GOLD PER SCEPTER:",
-        "value": "6",
+        "value": "3",
         "generated": true
       },
       {
@@ -42378,18 +42657,18 @@
       {
         "key": "bonus_gold_cap",
         "header": "BONUS GOLD CAP:",
-        "value": "18",
+        "value": "16",
         "generated": true
       },
       {
         "key": "bonus_gold_cap_tooltip",
         "header": "MAX BONUS GOLD PER KILL:",
-        "value": "18"
+        "value": "16"
       },
       {
         "key": "scepter_bonus_damage",
         "header": "SCEPTER BONUS DAMAGE:",
-        "value": "25",
+        "value": "15",
         "generated": true
       },
       {
@@ -42444,8 +42723,8 @@
         "key": "bonus_health_regen",
         "header": "BONUS HEALTH REGEN:",
         "value": [
-          "60",
-          "90",
+          "50",
+          "85",
           "120"
         ]
       },
@@ -42563,8 +42842,7 @@
           "6",
           "7",
           "8",
-          "9",
-          "10"
+          "9"
         ]
       },
       {
@@ -42622,8 +42900,7 @@
           "3.6%",
           "4.2%",
           "4.8%",
-          "5.4%",
-          "6%"
+          "5.4%"
         ]
       },
       {
@@ -42638,8 +42915,7 @@
           "6",
           "7",
           "8",
-          "9",
-          "10"
+          "9"
         ]
       },
       {
@@ -42697,8 +42973,7 @@
           "12",
           "14",
           "16",
-          "18",
-          "20"
+          "18"
         ]
       },
       {
@@ -42751,7 +43026,7 @@
       "No Target",
       "Instant Cast"
     ],
-    "desc": "Combines the properties of the elements currently being manipulated to create a new spell for Invoker to use. Invoke cooldown is reduced by 0.3 seconds for each orb level.\n\nInvoker's vast knowledge of magic allows him to choose from Multiple Aghanim's Scepter and Shard options. The items must be activated before they can be used, and cannot be changed after they are chosen.\n\n Click the help button to see the list of possible spells.",
+    "desc": "Combines the properties of the elements currently being manipulated to create a new spell for Invoker to use. Invoke cooldown is reduced by 0.3 seconds for each orb level. Invoker gains a bonus ability point for his orbs at levels 6, 12, and 18.\n\nInvoker's vast knowledge of magic allows him to choose from Multiple Aghanim's Scepter and Shard options. The items must be activated before they can be used, and cannot be changed after they are chosen.\n\n Click the help button to see the list of possible spells.",
     "attrib": [
       {
         "key": "max_invoked_spells",
@@ -42762,6 +43037,24 @@
         "key": "cooldown_reduction_per_orb",
         "header": "COOLDOWN REDUCTION PER ORB:",
         "value": "0.3",
+        "generated": true
+      },
+      {
+        "key": "first_ability_level",
+        "header": "FIRST ABILITY LEVEL:",
+        "value": "6",
+        "generated": true
+      },
+      {
+        "key": "second_ability_level",
+        "header": "SECOND ABILITY LEVEL:",
+        "value": "12",
+        "generated": true
+      },
+      {
+        "key": "third_ability_level",
+        "header": "THIRD ABILITY LEVEL:",
+        "value": "18",
         "generated": true
       }
     ],
@@ -42811,9 +43104,7 @@
           "5",
           "5.4",
           "5.8",
-          "6.2",
-          "6.6",
-          "7"
+          "6.2"
         ]
       },
       {
@@ -42833,9 +43124,7 @@
           "0.65",
           "0.62",
           "0.59",
-          "0.56",
-          "0.53",
-          "0.50"
+          "0.56"
         ]
       },
       {
@@ -42850,9 +43139,7 @@
           "68",
           "76",
           "84",
-          "92",
-          "100",
-          "108"
+          "92"
         ]
       },
       {
@@ -42918,9 +43205,7 @@
           "-45%",
           "-50%",
           "-55%",
-          "-60%",
-          "-65%",
-          "-70%"
+          "-60%"
         ]
       },
       {
@@ -42935,9 +43220,7 @@
           "5%",
           "10%",
           "15%",
-          "20%",
-          "25%",
-          "30%"
+          "20%"
         ]
       },
       {
@@ -42958,9 +43241,7 @@
           "12",
           "14",
           "16",
-          "18",
-          "20",
-          "22"
+          "18"
         ]
       },
       {
@@ -42975,9 +43256,7 @@
           "12",
           "14",
           "16",
-          "18",
-          "20",
-          "22"
+          "18"
         ]
       },
       {
@@ -42995,7 +43274,7 @@
     ],
     "lore": "Myrault's Hinder-Gast.",
     "mc": "175",
-    "cd": "32",
+    "cd": "40",
     "img": "/apps/dota2/images/dota_react/abilities/invoker_ghost_walk.png"
   },
   "invoker_tornado": {
@@ -43021,9 +43300,7 @@
           "3000",
           "3300",
           "3600",
-          "3900",
-          "4200",
-          "4500"
+          "3900"
         ]
       },
       {
@@ -43061,9 +43338,7 @@
           "2.2",
           "2.4",
           "2.6",
-          "2.8",
-          "3",
-          "3.2"
+          "2.8"
         ]
       },
       {
@@ -43089,9 +43364,7 @@
           "270",
           "315",
           "360",
-          "405",
-          "450",
-          "495"
+          "405"
         ]
       },
       {
@@ -43173,9 +43446,7 @@
           "475",
           "550",
           "625",
-          "700",
-          "775",
-          "850"
+          "700"
         ]
       },
       {
@@ -43243,9 +43514,7 @@
           "70",
           "82",
           "94",
-          "106",
-          "118",
-          "130"
+          "106"
         ]
       },
       {
@@ -43260,9 +43529,7 @@
           "70",
           "82",
           "94",
-          "106",
-          "118",
-          "130"
+          "106"
         ]
       },
       {
@@ -43326,9 +43593,7 @@
           "1245",
           "1410",
           "1575",
-          "1725",
-          "1890",
-          "2055"
+          "1725"
         ]
       },
       {
@@ -43359,16 +43624,14 @@
         "header": "CONTACT DAMAGE (EXORT):\\n",
         "value": [
           "55",
-          "80",
-          "105",
-          "130",
+          "75",
+          "95",
+          "115",
+          "135",
           "155",
-          "180",
-          "205",
-          "220",
-          "235",
-          "250",
-          "265"
+          "175",
+          "195",
+          "215"
         ]
       },
       {
@@ -43388,9 +43651,7 @@
           "35",
           "40",
           "45",
-          "50",
-          "55",
-          "60"
+          "50"
         ]
       },
       {
@@ -43455,9 +43716,7 @@
           "425",
           "475",
           "525",
-          "575",
-          "625",
-          "675"
+          "575"
         ]
       },
       {
@@ -43547,9 +43806,7 @@
           "70",
           "80",
           "90",
-          "100",
-          "110",
-          "120"
+          "100"
         ]
       },
       {
@@ -43564,9 +43821,7 @@
           "350",
           "400",
           "450",
-          "500",
-          "550",
-          "600"
+          "500"
         ],
         "generated": true
       },
@@ -43582,8 +43837,7 @@
           "5",
           "6",
           "7",
-          "8",
-          "9"
+          "8"
         ]
       },
       {
@@ -43598,9 +43852,7 @@
           "580",
           "635",
           "690",
-          "745",
-          "800",
-          "855"
+          "745"
         ]
       },
       {
@@ -43615,9 +43867,7 @@
           "800",
           "900",
           "1000",
-          "1100",
-          "1200",
-          "1300"
+          "1100"
         ]
       },
       {
@@ -43632,9 +43882,7 @@
           "54",
           "60",
           "66",
-          "72",
-          "78",
-          "84"
+          "72"
         ]
       },
       {
@@ -43649,9 +43897,7 @@
           "1.3",
           "1.4",
           "1.5",
-          "1.6",
-          "1.7",
-          "1.8"
+          "1.6"
         ],
         "generated": true
       },
@@ -43667,8 +43913,6 @@
           "2",
           "2",
           "3",
-          "3",
-          "3",
           "3"
         ]
       },
@@ -43683,8 +43927,6 @@
           "2",
           "2",
           "2",
-          "3",
-          "3",
           "3",
           "3"
         ]
@@ -43822,8 +44064,7 @@
           "1.3",
           "1.4",
           "1.5",
-          "1.6",
-          "1.7"
+          "1.6"
         ]
       },
       {
@@ -43862,26 +44103,22 @@
           "8",
           "9",
           "10",
-          "11",
-          "12",
-          "13"
+          "11"
         ]
       },
       {
         "key": "slow",
         "header": "MOVEMENT SLOW (QUAS):\\n",
         "value": [
-          "-20%",
-          "-40%",
+          "-30%",
+          "-45%",
           "-60%",
-          "-80%",
-          "-100%",
+          "-75%",
+          "-90%",
+          "-105%",
           "-120%",
-          "-140%",
-          "-160%",
-          "-180%",
-          "-200%",
-          "-220%"
+          "-135%",
+          "-150%"
         ]
       },
       {
@@ -43901,8 +44138,7 @@
           "60",
           "66",
           "72",
-          "78",
-          "84"
+          "78"
         ]
       },
       {
@@ -44025,9 +44261,7 @@
           "270",
           "310",
           "350",
-          "390",
-          "430",
-          "470"
+          "390"
         ]
       },
       {
@@ -44042,9 +44276,7 @@
           "1.6",
           "1.7",
           "1.8",
-          "1.9",
-          "2",
-          "2.1"
+          "1.9"
         ]
       },
       {
@@ -44059,9 +44291,7 @@
           "4",
           "4.5",
           "5",
-          "5.5",
-          "6",
-          "6.5"
+          "5.5"
         ]
       },
       {
@@ -45377,7 +45607,7 @@
     ],
     "dmg_type": "Magical",
     "bkbpierce": "No",
-    "desc": "Unleashes a psychic blast that deals damage to enemies based on the difference between your mana and the target's mana. Sanity's Eclipse can hit units trapped by Astral Imprisonment.",
+    "desc": "Unleashes a psychic blast that deals damage to enemies based on the difference between your max mana and the target's max mana. Sanity's Eclipse can hit units trapped by Astral Imprisonment.",
     "attrib": [
       {
         "key": "base_damage",
@@ -45392,8 +45622,8 @@
         "key": "radius",
         "header": "RADIUS:",
         "value": [
-          "450",
           "500",
+          "525",
           "550"
         ]
       },
@@ -45404,7 +45634,7 @@
       },
       {
         "key": "damage_multiplier",
-        "header": "MANA DIFFERENCE MULTIPLIER:",
+        "header": "MAX MANA DIFFERENCE MULTIPLIER:",
         "value": "0.4"
       },
       {
@@ -45500,7 +45730,7 @@
         "generated": true
       }
     ],
-    "mc": "250",
+    "mc": "175",
     "cd": [
       "36",
       "34",
@@ -45768,10 +45998,10 @@
         "key": "bonus_hp_regen",
         "header": "BONUS HP REGEN:",
         "value": [
-          "1",
-          "3",
-          "5",
-          "7"
+          "2",
+          "4",
+          "6",
+          "8"
         ]
       },
       {
@@ -45849,9 +46079,9 @@
     "lore": "Forever a slave to his lycanthropy, Banehallow has come to accept his curse, and embrace his own savagery.",
     "mc": "100",
     "cd": [
-      "110",
-      "100",
-      "90"
+      "105",
+      "95",
+      "85"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/lycan_shapeshift.png"
   },
@@ -46076,7 +46306,12 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "4"
+        "value": [
+          "4",
+          "4.25",
+          "4.5",
+          "4.75"
+        ]
       },
       {
         "key": "abilitycastpoint",
@@ -46611,7 +46846,7 @@
     "desc": "Cancel the Primal Split.",
     "attrib": [],
     "mc": "0",
-    "cd": "0",
+    "cd": "3",
     "img": "/apps/dota2/images/dota_react/abilities/brewmaster_primal_split_cancel.png"
   },
   "brewmaster_primal_companion": {
@@ -47021,9 +47256,9 @@
         "key": "illusion_duration",
         "header": "ILLUSION DURATION:",
         "value": [
-          "11",
+          "8",
+          "10",
           "12",
-          "13",
           "14"
         ]
       },
@@ -47291,7 +47526,7 @@
     "dmg_type": "Magical",
     "bkbpierce": "No",
     "dispellable": "No",
-    "desc": "Deals damage in a line, and afflicts enemy units with a poison effect. The poison deals 1/2/4/8/16 times the stack damage based on the number of stacks on the target, up to 5 stacks. Additional stacks cause 50 damage each. This deferred damage is dealt when Shadow Poison's duration is expired, or the Release sub-ability is used.",
+    "desc": "Deals damage in a line, and afflicts enemy units with a poison effect. The poison deals 1/2/4/8/16 times the stack damage based on the number of stacks on the target, up to 5 stacks. Additional stacks cause 60 damage each. This deferred damage is dealt when Shadow Poison's duration is expired, or the Release sub-ability is used.",
     "attrib": [
       {
         "key": "stack_damage",
@@ -47311,7 +47546,7 @@
       {
         "key": "bonus_stack_damage",
         "header": "BONUS STACK DAMAGE:",
-        "value": "50",
+        "value": "60",
         "generated": true
       },
       {
@@ -47360,7 +47595,7 @@
       }
     ],
     "lore": "The ever growing influence of the Shadow Demon can pollute the most valiant and pure of heroes.",
-    "mc": "45",
+    "mc": "40",
     "cd": "2.5",
     "img": "/apps/dota2/images/dota_react/abilities/shadow_demon_shadow_poison.png"
   },
@@ -47632,7 +47867,7 @@
       {
         "key": "bear_regen_tooltip",
         "header": "BEAR BASE HP REGEN:",
-        "value": "3"
+        "value": "1.5"
       },
       {
         "key": "bear_bat",
@@ -47714,7 +47949,7 @@
       }
     ],
     "lore": "Sylla's lifelong companion is symbiotic with his spirit and heart, coming to aid him in any time of need.",
-    "mc": "75",
+    "mc": "100",
     "cd": "120",
     "img": "/apps/dota2/images/dota_react/abilities/lone_druid_spirit_bear.png"
   },
@@ -47794,6 +48029,12 @@
         ]
       },
       {
+        "key": "creep_lifesteal_penalty",
+        "header": "CREEP LIFESTEAL PENALTY:",
+        "value": "40",
+        "generated": true
+      },
+      {
         "key": "lifesteal_both_ways",
         "header": "LIFESTEAL BOTH WAYS:",
         "value": "1",
@@ -47851,6 +48092,12 @@
           "45%",
           "60%"
         ]
+      },
+      {
+        "key": "creep_lifesteal_penalty",
+        "header": "CREEP LIFESTEAL PENALTY:",
+        "value": "40",
+        "generated": true
       },
       {
         "key": "lifesteal_both_ways",
@@ -48376,7 +48623,7 @@
     "img": "/apps/dota2/images/dota_react/abilities/lone_druid_spirit_bear_demolish.png"
   },
   "special_bonus_unique_lone_druid_2": {
-    "dname": "-25s Summon Spirit Bear Cooldown"
+    "dname": "+5s True Form Duration"
   },
   "special_bonus_unique_lone_druid_4": {
     "dname": "-5s Savage Roar Cooldown"
@@ -48398,7 +48645,7 @@
     "dname": "+15% Damage to Entangled Units"
   },
   "special_bonus_unique_lone_druid_spirit_bear_demolish": {
-    "dname": "+20% Demolish Bonus Building Damage"
+    "dname": "+15% Demolish Bonus Building Damage"
   },
   "special_bonus_unique_lone_druid_spirit_bear_return_channel": {
     "dname": "-{s:bonus_AbilityChannelTime}s Return Channel Time"
@@ -48614,10 +48861,10 @@
         "key": "crit_max",
         "header": "CRITICAL MAX:",
         "value": [
-          "140%",
-          "180%",
-          "220%",
-          "260%"
+          "150%",
+          "190%",
+          "230%",
+          "270%"
         ]
       },
       {
@@ -48645,16 +48892,12 @@
     "behavior": "No Target",
     "target_team": "Friendly",
     "target_type": "Hero",
-    "desc": "Summons several phantasmal copies of the Chaos Knight from alternate dimensions. The phantasms are illusions that deal 100% damage, but take 350% damage.\nDISPEL TYPE: Basic Dispel",
+    "desc": "Summons several phantasmal copies of the Chaos Knight from alternate dimensions. The phantasms are illusions that deal 60% damage, but take 350% damage.\nDISPEL TYPE: Basic Dispel",
     "attrib": [
       {
         "key": "images_count",
         "header": "NUMBER OF PHANTASMS:",
-        "value": [
-          "1",
-          "2",
-          "3"
-        ]
+        "value": "3"
       },
       {
         "key": "illusion_duration",
@@ -48664,13 +48907,21 @@
       {
         "key": "outgoing_damage",
         "header": "OUTGOING DAMAGE:",
-        "value": "0",
+        "value": [
+          "-40",
+          "-20",
+          "0"
+        ],
         "generated": true
       },
       {
         "key": "outgoing_damage_tooltip",
         "header": "PHANTASM DAMAGE:",
-        "value": "100%"
+        "value": [
+          "60%",
+          "80%",
+          "100%"
+        ]
       },
       {
         "key": "incoming_damage",
@@ -48726,7 +48977,11 @@
       "200",
       "300"
     ],
-    "cd": "75",
+    "cd": [
+      "85",
+      "80",
+      "75"
+    ],
     "img": "/apps/dota2/images/dota_react/abilities/chaos_knight_phantasm.png"
   },
   "chaos_knight_phantasmagoria": {
@@ -48917,10 +49172,10 @@
         "key": "health_steal_heroes",
         "header": "HEALTH STEAL (HEROES):",
         "value": [
-          "9",
-          "12",
-          "15",
-          "18"
+          "7",
+          "10",
+          "13",
+          "16"
         ]
       }
     ],
@@ -48930,7 +49185,7 @@
   "meepo_divided_we_stand": {
     "dname": "Divided We Stand",
     "behavior": "Passive",
-    "desc": "Meepo summons another Meepo, which levels up and shares items with the main Meepo. Ability cooldowns are independent, but items share cooldowns between Meepos. Damage, attack speed, health / mana regeneration, mana burn, and proc chance bonuses from items are distributed equally among the amount of Meepos.\n\nIf any Meepo dies, they all die.",
+    "desc": "Meepo summons another Meepo, which levels up and shares items and experience with the main Meepo. Ability cooldowns are independent, but items share cooldowns between Meepos, except Teleport Scrolls. \n\nDamage, attack speed, health, mana, regeneration, mana burn, and proc chance bonuses from items are distributed equally among the amount of Meepos, making them 50% less effective.\n\nIf any Meepo dies, they all die.",
     "dmg": "0",
     "attrib": [
       {
@@ -48971,6 +49226,12 @@
           "80"
         ],
         "generated": true
+      },
+      {
+        "key": "attribute_penalty_pct",
+        "header": "ATTRIBUTE PENALTY PCT:",
+        "value": "0",
+        "generated": true
       }
     ],
     "lore": "Do I know you?",
@@ -48994,7 +49255,7 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "25"
+        "value": "20"
       },
       {
         "key": "model_scale",
@@ -49047,7 +49308,7 @@
     ],
     "lore": "Hi, Meepos!",
     "mc": "0",
-    "cd": "60",
+    "cd": "90",
     "img": "/apps/dota2/images/dota_react/abilities/meepo_megameepo.png"
   },
   "meepo_megameepo_fling": {
@@ -49481,9 +49742,9 @@
     "lore": "The tendrils of Rooftrellen's influence stretch to all corners of the forest.",
     "mc": "90",
     "cd": [
-      "20",
+      "23",
+      "21",
       "19",
-      "18",
       "17"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/treant_natures_grasp.png"
@@ -49722,7 +49983,8 @@
     "dname": "Eyes In The Forest",
     "behavior": [
       "Unit Target",
-      "Hidden"
+      "Hidden",
+      "AOE"
     ],
     "target_type": "Tree",
     "desc": "Treant Protector enchants a tree, which grants him unobstructed vision in that location. The eyes last for 360 seconds and are invisible, but are destroyed if their host tree is destroyed or if they are attacked directly.",
@@ -51030,9 +51292,9 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "100",
-          "175",
-          "250",
+          "85",
+          "165",
+          "245",
           "325"
         ]
       },
@@ -51054,7 +51316,7 @@
       {
         "key": "duration",
         "header": "DEBUFF DURATION:",
-        "value": "10"
+        "value": "9"
       },
       {
         "key": "radius",
@@ -51359,6 +51621,11 @@
     "attrib": [],
     "img": "/apps/dota2/images/dota_react/abilities/rubick_hidden4.png"
   },
+  "rubick_hidden5": {
+    "behavior": "Hidden",
+    "attrib": [],
+    "img": "/apps/dota2/images/dota_react/abilities/rubick_hidden5.png"
+  },
   "disruptor_thunder_strike": {
     "dname": "Thunder Strike",
     "behavior": "Unit Target",
@@ -51442,10 +51709,10 @@
     ],
     "lore": "Disruptor's charged coils occasionally overload, and a singed armor plate or tuft of fur is the enemy's result.",
     "mc": [
+      "115",
+      "120",
       "125",
-      "130",
-      "135",
-      "140"
+      "130"
     ],
     "cd": [
       "18",
@@ -52104,7 +52371,11 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "60"
+        "value": [
+          "45",
+          "50",
+          "55"
+        ]
       },
       {
         "key": "fade_time",
@@ -52581,7 +52852,7 @@
       {
         "key": "evasion_per_naga",
         "header": "EVASION PER NAGA:",
-        "value": "4.9%"
+        "value": "4%"
       },
       {
         "key": "radius",
@@ -53218,8 +53489,8 @@
         "header": "CAST RANGE BONUS:",
         "value": [
           "100",
-          "200",
-          "300"
+          "175",
+          "250"
         ]
       },
       {
@@ -53443,12 +53714,12 @@
     "dname": "Bright Speed",
     "is_innate": true,
     "behavior": "Passive",
-    "desc": "Keeper of the Light gains 1 movement speed for every 2.5 Intelligence.\n\nWhenever Keeper of the Light moves 300 distance, he leaves behind light that allows him to see 400 range for 3 seconds.",
+    "desc": "Keeper of the Light gains 1 movement speed for every 3 Intelligence.\n\nWhenever Keeper of the Light moves 300 distance, he leaves behind light that allows him to see 400 range for 3 seconds.",
     "attrib": [
       {
         "key": "intelligence_per_speed",
         "header": "INTELLIGENCE PER SPEED:",
-        "value": "2.5",
+        "value": "3",
         "generated": true
       },
       {
@@ -53512,20 +53783,20 @@
         "key": "tether_heal_amp",
         "header": "HP/MANA TRANSFER:",
         "value": [
-          "60%",
-          "80%",
-          "100%",
-          "120%"
+          "55%",
+          "75%",
+          "95%",
+          "115%"
         ]
       },
       {
         "key": "tether_mana_amp",
         "header": "TETHER MANA AMP:",
         "value": [
-          "60",
-          "80",
-          "100",
-          "120"
+          "55",
+          "75",
+          "95",
+          "115"
         ],
         "generated": true
       },
@@ -53633,6 +53904,12 @@
         "key": "min_range",
         "header": "MIN RANGE:",
         "value": "200",
+        "generated": true
+      },
+      {
+        "key": "default_radius",
+        "header": "DEFAULT RADIUS:",
+        "value": "425",
         "generated": true
       },
       {
@@ -53898,12 +54175,12 @@
       {
         "key": "damage_amplification",
         "header": "MAX DAMAGE AMP:",
-        "value": "5%"
+        "value": "4%"
       },
       {
         "key": "heal_amplification",
         "header": "MAX HEAL AMP:",
-        "value": "5%"
+        "value": "4%"
       }
     ],
     "img": "/apps/dota2/images/dota_react/abilities/wisp_equilibrium.png"
@@ -53939,10 +54216,10 @@
         "key": "attackspeed_bonus",
         "header": "ATTACK SPEED DRAIN:",
         "value": [
-          "25",
-          "40",
+          "35",
+          "45",
           "55",
-          "70"
+          "65"
         ]
       },
       {
@@ -54129,6 +54406,12 @@
         "key": "minimum_damage",
         "header": "MINIMUM DAMAGE:",
         "value": "40"
+      },
+      {
+        "key": "minimum_damage_familiars",
+        "header": "MINIMUM DAMAGE FAMILIARS:",
+        "value": "0",
+        "generated": true
       },
       {
         "key": "radius",
@@ -54808,7 +55091,7 @@
       {
         "key": "duration",
         "header": "DURATION:",
-        "value": "12.5"
+        "value": "10"
       },
       {
         "key": "steal_radius",
@@ -54838,9 +55121,9 @@
         "key": "bonus_movement_speed",
         "header": "BONUS MOVEMENT SPEED:",
         "value": [
-          "24%",
-          "36%",
-          "48%"
+          "20%",
+          "30%",
+          "40%"
         ]
       },
       {
@@ -54975,10 +55258,10 @@
       "40"
     ],
     "cd": [
-      "14",
       "12",
-      "10",
-      "8"
+      "10.5",
+      "9",
+      "7.5"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/slark_saltwater_shiv.png"
   },
@@ -55757,10 +56040,10 @@
         "key": "damage",
         "header": "DAMAGE:",
         "value": [
-          "50",
-          "100",
-          "150",
-          "200"
+          "75",
+          "120",
+          "165",
+          "210"
         ]
       },
       {
@@ -55908,11 +56191,7 @@
       {
         "key": "movement_speed",
         "header": "MOVEMENT SPEED:",
-        "value": [
-          "25%",
-          "30%",
-          "35%"
-        ]
+        "value": "35%"
       },
       {
         "key": "range",
@@ -56330,12 +56609,12 @@
     "dname": "Horsepower",
     "is_innate": true,
     "behavior": "Passive",
-    "desc": "Centaur Warrunner gains 30% of his strength as bonus movement speed.\n\n This Movement speed bonus does not stack with bonuses from boots.",
+    "desc": "Centaur Warrunner gains 40% of his strength as bonus movement speed.\n\n This Movement speed bonus does not stack with bonuses from boots.",
     "attrib": [
       {
         "key": "strength_to_movement_pct",
         "header": "STRENGTH TO MOVEMENT PCT:",
-        "value": "30",
+        "value": "40",
         "generated": true
       },
       {
@@ -56600,9 +56879,9 @@
         "key": "basic_slow_duration",
         "header": "SLOW DURATION:",
         "value": [
-          "0.4",
-          "0.6",
-          "0.8",
+          "0.55",
+          "0.7",
+          "0.85",
           "1"
         ]
       },
@@ -57113,7 +57392,7 @@
       {
         "key": "move_slow_pct",
         "header": "MOVE SLOW:",
-        "value": "30%"
+        "value": "40%"
       },
       {
         "key": "building_dmg_pct",
@@ -57157,10 +57436,10 @@
         "key": "whirling_damage",
         "header": "DAMAGE:",
         "value": [
-          "75",
+          "60",
           "120",
-          "165",
-          "210"
+          "180",
+          "240"
         ]
       },
       {
@@ -57193,10 +57472,10 @@
         "key": "duration",
         "header": "STAT LOSS DURATION:",
         "value": [
+          "7",
+          "9",
           "11",
-          "12",
-          "13",
-          "14"
+          "13"
         ]
       },
       {
@@ -57260,9 +57539,9 @@
         "header": "DAMAGE:",
         "value": [
           "45",
-          "100",
-          "155",
-          "210"
+          "105",
+          "165",
+          "225"
         ]
       },
       {
@@ -57303,10 +57582,10 @@
         "key": "bonus_hp_regen",
         "header": "BONUS HP REGEN:",
         "value": [
-          "0.4",
           "0.5",
           "0.6",
-          "0.7"
+          "0.7",
+          "0.8"
         ]
       },
       {
@@ -57367,9 +57646,9 @@
         "key": "pass_damage",
         "header": "PASS DAMAGE:",
         "value": [
-          "100",
+          "75",
           "150",
-          "200"
+          "225"
         ]
       },
       {
@@ -57402,9 +57681,9 @@
         "key": "mana_per_second",
         "header": "MANA COST PER SECOND:",
         "value": [
-          "14",
-          "22",
-          "30"
+          "10",
+          "15",
+          "20"
         ]
       },
       {
@@ -57440,9 +57719,9 @@
     ],
     "lore": "The ultimate in anti-flora weaponry.",
     "mc": [
-      "100",
-      "140",
-      "180"
+      "90",
+      "120",
+      "150"
     ],
     "cd": "8",
     "img": "/apps/dota2/images/dota_react/abilities/shredder_chakram.png"
@@ -57690,7 +57969,7 @@
       {
         "key": "mana_restore",
         "header": "MANA RESTORE:",
-        "value": "3.75"
+        "value": "4"
       },
       {
         "key": "health_restore",
@@ -57753,7 +58032,7 @@
     ],
     "lore": "Every part of Bristleback's body is a weapon -- even the parts he accidentally swallowed.",
     "mc": "60",
-    "cd": "13",
+    "cd": "15",
     "img": "/apps/dota2/images/dota_react/abilities/bristleback_hairball.png"
   },
   "bristleback_viscous_nasal_goo": {
@@ -58107,9 +58386,9 @@
         "key": "damage_per_stack",
         "header": "DAMAGE PER STACK:",
         "value": [
-          "15",
-          "20",
-          "25"
+          "12",
+          "16",
+          "20"
         ]
       },
       {
@@ -58486,14 +58765,14 @@
   },
   "tusk_drinking_buddies": {
     "dname": "Drinking Buddies",
-    "behavior": [],
+    "behavior": "Unit Target",
     "dispellable": "Yes",
     "target_team": "Friendly",
     "target_type": [
       "Hero",
       "Basic"
     ],
-    "desc": "Tusk reaches out to tag an allied unit, pulling them closer. Once tagged, both Tusk and his tagged ally gain movement speed and armor. Can be put on alt-cast to only pull Tusk towards his ally with 50% reduced cast range.",
+    "desc": "Tusk reaches out to tag an allied unit, pulling them closer. Once tagged, both Tusk and his tagged ally gain movement speed and armor.",
     "attrib": [
       {
         "key": "abilitycastrange",
@@ -58538,7 +58817,7 @@
       {
         "key": "armor_bonus",
         "header": "BONUS ARMOR:",
-        "value": "10"
+        "value": "7"
       },
       {
         "key": "abilitycastpoint",
@@ -58570,7 +58849,7 @@
       {
         "key": "attack_speed_slow",
         "header": "ATTACK SLOW:",
-        "value": "17"
+        "value": "12"
       }
     ],
     "img": "/apps/dota2/images/dota_react/abilities/tusk_bitter_chill.png"
@@ -58993,9 +59272,9 @@
       "800"
     ],
     "cd": [
-      "60",
-      "40",
-      "20"
+      "55",
+      "35",
+      "15"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/skywrath_mage_mystic_flare.png"
   },
@@ -59235,7 +59514,7 @@
       "Passive",
       "Hidden"
     ],
-    "desc": "Damaging enemies applies the Withering Mist debuff for 5s. Affected enemies have their Health Restoration reduced by 24.5% if they are below 40% HP.",
+    "desc": "Damaging enemies applies the Withering Mist debuff for 5s. Affected enemies have their Health Restoration reduced by 29.5% if they are below 40% HP.",
     "attrib": [
       {
         "key": "hp_threshold_pct",
@@ -59246,7 +59525,7 @@
       {
         "key": "heal_reduction_pct",
         "header": "HEALTH RESTORATION REDUCTION:",
-        "value": "24.5%"
+        "value": "29.5%"
       },
       {
         "key": "duration",
@@ -59392,7 +59671,7 @@
     "dname": "350 AoE Mist Coil"
   },
   "special_bonus_unique_abaddon_5": {
-    "dname": "+25 Curse of Avernus DPS"
+    "dname": "+30 Curse of Avernus DPS"
   },
   "special_bonus_unique_abaddon_6": {
     "dname": "+{s:bonus_heal_reduction_pct}% Withering Mist Health Restoration Reduction"
@@ -59438,10 +59717,10 @@
         "key": "stomp_damage",
         "header": "STOMP DAMAGE:",
         "value": [
-          "60",
-          "100",
-          "140",
-          "180"
+          "65",
+          "110",
+          "155",
+          "200"
         ]
       },
       {
@@ -59910,7 +60189,7 @@
       {
         "key": "radius",
         "header": "RADIUS:",
-        "value": "350"
+        "value": "375"
       },
       {
         "key": "armor_reduction_pct",
@@ -59950,7 +60229,7 @@
       {
         "key": "radius",
         "header": "RADIUS:",
-        "value": "350"
+        "value": "375"
       },
       {
         "key": "armor_reduction_pct",
@@ -60008,8 +60287,8 @@
         "key": "slow_pct",
         "header": "MOVEMENT SLOW:",
         "value": [
-          "30%",
           "40%",
+          "45%",
           "50%"
         ]
       },
@@ -60103,7 +60382,7 @@
       {
         "key": "armor_from_movespeed",
         "header": "BONUS SPEED TO ARMOR:",
-        "value": "3.6%"
+        "value": "5%"
       }
     ],
     "img": "/apps/dota2/images/dota_react/abilities/elder_titan_momentum.png"
@@ -60421,7 +60700,11 @@
       }
     ],
     "lore": "To face a soldier of Stonehall in single combat is a challenge few can resist.",
-    "mc": "75",
+    "mc": [
+      "80",
+      "100",
+      "120"
+    ],
     "cd": [
       "60",
       "55",
@@ -60436,7 +60719,7 @@
       "Passive",
       "Hidden"
     ],
-    "desc": "Passively grants Legion Commander armor.\n\nIf Legion or an allied Hero within 1200 range casts an ability, they gain bonus armor for 6s; allies gain 50% of the value. This bonus stacks independently.",
+    "desc": "When Legion Commander or an allied Hero within 1200 range casts an ability, they gain bonus armor for 6s; allies gain 50% of the value. This bonus stacks independently.",
     "attrib": [
       {
         "key": "radius",
@@ -60636,10 +60919,10 @@
         "key": "bonus_hero_damage",
         "header": "BONUS HERO DAMAGE:",
         "value": [
-          "50",
-          "90",
-          "130",
-          "170"
+          "40",
+          "80",
+          "120",
+          "160"
         ]
       },
       {
@@ -60696,12 +60979,7 @@
       }
     ],
     "lore": "The studied warrior must whip and weave through its enemies, burning each without pause.",
-    "mc": [
-      "60",
-      "65",
-      "70",
-      "75"
-    ],
+    "mc": "75",
     "cd": [
       "13",
       "11",
@@ -61309,7 +61587,7 @@
     "dname": "Stone Remnant",
     "is_innate": true,
     "behavior": "Point Target",
-    "desc": "Call a Stone Remnant to the target location. Stone Remnants have no vision and are invulnerable, and can be used with Earth Spirit's abilities. Calling a Stone Remnant consumes a charge, which recharge over time. Stone Remnant has 7 charges.\n\nEarth Spirit passively gains 2.5% bonus damage per unused Stone Remnant charge, and gains an additional 7.5% bonus damage for 10s when a Stone Remnant is targeted with an ability (does not stack).",
+    "desc": "Call a Stone Remnant to the target location. Stone Remnants have no vision and are invulnerable, and can be used with Earth Spirit's abilities. Calling a Stone Remnant consumes a charge, which recharge over time. Stone Remnant has 7 charges.\n\nEarth Spirit passively gains 3% bonus damage per unused Stone Remnant charge, and gains an additional 7.5% bonus damage for 10s when a Stone Remnant is targeted with an ability (does not stack).",
     "attrib": [
       {
         "key": "duration",
@@ -61355,7 +61633,7 @@
       {
         "key": "attack_damage_per_stone",
         "header": "ATTACK DAMAGE PER STONE:",
-        "value": "2.5",
+        "value": "3",
         "generated": true
       },
       {
@@ -62174,9 +62452,9 @@
         "key": "attackspeed_slow",
         "header": "ATTACK SPEED SLOW:",
         "value": [
-          "-50",
-          "-80",
-          "-110",
+          "-35",
+          "-70",
+          "-105",
           "-140"
         ]
       },
@@ -62225,7 +62503,7 @@
     "dmg_type": "Magical",
     "bkbpierce": "No",
     "dispellable": "No",
-    "desc": "Phoenix expels a beam of light at the cost of its own health. The beam damages enemies and heals allies for a base amount plus a percentage of their health. The percentage increases as the beam continues to fire.",
+    "desc": "Phoenix expels a beam of light at the cost of its own health. The beam damages enemies and heals allies for a base amount plus a percentage of their max health. The percentage increases as the beam continues to fire.",
     "attrib": [
       {
         "key": "hp_cost_perc_per_second",
@@ -62244,7 +62522,7 @@
       },
       {
         "key": "hp_perc_damage",
-        "header": "MAX DAMAGE:",
+        "header": "MAX HEALTH AS DAMAGE:",
         "value": [
           "1.5%",
           "3%",
@@ -62264,12 +62542,12 @@
       },
       {
         "key": "hp_perc_heal",
-        "header": "MAX HEAL:",
+        "header": "MAX HEALTH AS HEAL:",
         "value": [
-          "0.5%",
-          "1%",
-          "1.5%",
-          "2%"
+          "0.4%",
+          "0.8%",
+          "1.2%",
+          "1.6%"
         ]
       },
       {
@@ -62300,6 +62578,12 @@
         "key": "turn_rate",
         "header": "TURN RATE:",
         "value": "25",
+        "generated": true
+      },
+      {
+        "key": "shard_move_slow_pct",
+        "header": "SHARD MOVE SLOW PCT:",
+        "value": "0",
         "generated": true
       },
       {
@@ -62389,9 +62673,9 @@
         "key": "damage_per_sec",
         "header": "DAMAGE PER SECOND:",
         "value": [
-          "60",
-          "90",
-          "120"
+          "50",
+          "80",
+          "110"
         ]
       },
       {
@@ -62486,9 +62770,9 @@
         "key": "attackspeed_slow",
         "header": "ATTACK SPEED SLOW:",
         "value": [
-          "-50",
-          "-80",
-          "-110",
+          "-35",
+          "-70",
+          "-105",
           "-140"
         ]
       },
@@ -62534,7 +62818,7 @@
       "Hidden"
     ],
     "dispellable": "No",
-    "desc": "Phoenix deals 4% of its missing health as magic damage to all enemies in a 400 radius every second.",
+    "desc": "Phoenix deals 3.5% of its missing health as magic damage to all enemies in a 400 radius every second.",
     "attrib": [
       {
         "key": "radius",
@@ -62545,7 +62829,7 @@
       {
         "key": "damage_pct",
         "header": "DAMAGE PCT:",
-        "value": "4",
+        "value": "3.5",
         "generated": true
       },
       {
@@ -62591,7 +62875,7 @@
     "dname": "+1000 Icarus Dive Cast Range"
   },
   "special_bonus_unique_phoenix_5": {
-    "dname": "+1.5% Max Health Sun Ray Damage"
+    "dname": "+1.25% Max Health Sun Ray Damage"
   },
   "special_bonus_unique_phoenix_6": {
     "dname": "+25% Icarus Dive Slow"
@@ -62684,7 +62968,7 @@
       }
     ],
     "lore": "The astral orb crackles with power while raw energy lances out, temporarily disrupting an enemy's connection to their own body.",
-    "mc": "100",
+    "mc": "80",
     "cd": [
       "18",
       "14",
@@ -63049,7 +63333,7 @@
     "dmg_type": "Magical",
     "bkbpierce": "No",
     "dispellable": "Yes",
-    "desc": "Plant an invisible mine that cannot be detected by True Sight, but is visible if an enemy is within the active 500 AoE of the mine. Mines detonate if an enemy is standing within the active AoE for 1 seconds dealing damage and temporarily reducing the enemy's Magic Resistance. The explosion deals full damage if the target is within 150 radius and decreases up to 60% on the edge. Deals 30% damage to buildings.",
+    "desc": "Plant an invisible mine that cannot be detected by True Sight, but is visible if an enemy is within the active 500 AoE of the mine. Mines detonate if an enemy is standing within the active AoE for 1 seconds dealing damage and temporarily reducing the enemy's Magic Resistance. The explosion deals full damage if the target is within 150 radius and decreases down to 50% on the edge. Deals 30% damage to buildings.",
     "attrib": [
       {
         "key": "radius",
@@ -63067,8 +63351,8 @@
         "header": "DAMAGE:",
         "value": [
           "400",
-          "575",
-          "750"
+          "550",
+          "700"
         ]
       },
       {
@@ -63090,7 +63374,7 @@
       {
         "key": "outer_damage",
         "header": "OUTER DAMAGE:",
-        "value": "60",
+        "value": "50",
         "generated": true
       },
       {
@@ -63117,7 +63401,7 @@
       {
         "key": "burn_duration",
         "header": "DEBUFF DURATION:",
-        "value": "5"
+        "value": "4"
       },
       {
         "key": "abilitycastrange",
@@ -63531,10 +63815,10 @@
         "key": "disarm_duration",
         "header": "DISARM DURATION:",
         "value": [
-          "2.4",
-          "2.7",
-          "3",
-          "3.3"
+          "2.25",
+          "2.5",
+          "2.75",
+          "3"
         ]
       },
       {
@@ -63550,7 +63834,7 @@
       {
         "key": "explosion_radius",
         "header": "EXPLOSION RADIUS:",
-        "value": "450"
+        "value": "400"
       },
       {
         "key": "damage",
@@ -63852,7 +64136,7 @@
       {
         "key": "bonus_mana_as_mana_regen",
         "header": "MANA POOL AS REGEN:",
-        "value": "0.08%"
+        "value": "0.1%"
       },
       {
         "key": "radius",
@@ -64008,7 +64292,7 @@
       "Hero",
       "Basic"
     ],
-    "desc": "Launches a ball of brittle ice toward a unit. The ice shatters on impact, leaving the primary target completely unaffected, while hurling damaging splinters into nearby enemies in a 500 base radius. Enemies struck by these splinters are slowed by 28%.",
+    "desc": "Launches a ball of brittle ice toward a unit. The ice shatters on impact, leaving the primary target completely unaffected, while hurling damaging splinters into nearby enemies in a 500 base radius. Enemies struck by these splinters are slowed by 27%.",
     "attrib": [
       {
         "key": "projectile_speed",
@@ -64031,10 +64315,10 @@
         "key": "bonus_movespeed",
         "header": "BONUS MOVESPEED:",
         "value": [
-          "-28",
-          "-32",
-          "-36",
-          "-40"
+          "-27",
+          "-30",
+          "-33",
+          "-36"
         ],
         "generated": true
       },
@@ -64042,10 +64326,10 @@
         "key": "movespeed_slow_tooltip",
         "header": "MOVEMENT SLOW:",
         "value": [
-          "28%",
-          "32%",
-          "36%",
-          "40%"
+          "27%",
+          "30%",
+          "33%",
+          "36%"
         ]
       },
       {
@@ -64186,7 +64470,7 @@
     "bkbpierce": "Yes",
     "target_team": "Enemy",
     "target_type": "Hero",
-    "desc": "Winter Wyvern dispells then freezes an enemy in place while striking those nearby with a maddening curse which causes them to attack their frozen ally with increased attack speed. The frozen ally and those cursed to attack their ally are immune to all damage from their enemies with the exception of damage from Winter Wyvern or her controlled units.",
+    "desc": "Winter Wyvern dispells then freezes an enemy in place while striking those nearby with a maddening curse which causes them to attack their frozen ally with increased attack speed. The frozen ally and those cursed to attack their ally are immune to all damage from their enemies with the exception of damage from Winter Wyvern or her controlled units. Enemy heroes which enter the cursed area after the cast add to the duration of the curse.",
     "attrib": [
       {
         "key": "radius",
@@ -64322,7 +64606,7 @@
     "img": "/apps/dota2/images/dota_react/abilities/winter_wyvern_eldwurms_edda.png"
   },
   "special_bonus_unique_winter_wyvern_1": {
-    "dname": "+15% Arctic Burn Slow"
+    "dname": "+10% Arctic Burn Slow"
   },
   "special_bonus_unique_winter_wyvern_2": {
     "dname": "+175 Splinter Blast Shatter Radius"
@@ -64334,7 +64618,7 @@
     "dname": "Splinter Blast 1s Stun"
   },
   "special_bonus_unique_winter_wyvern_5": {
-    "dname": "+20 HP/s Cold Embrace Heal"
+    "dname": "+15 Cold Embrace Base Heal Per Second"
   },
   "special_bonus_unique_winter_wyvern_6": {
     "dname": "+3s Arctic Burn Debuff Duration"
@@ -64469,9 +64753,9 @@
         "key": "move_speed_slow_pct",
         "header": "MOVEMENT SPEED SLOW:",
         "value": [
-          "14%",
-          "21%",
-          "28%",
+          "20%",
+          "25%",
+          "30%",
           "35%"
         ]
       },
@@ -64479,10 +64763,10 @@
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
         "value": [
-          "500",
-          "600",
+          "625",
           "700",
-          "800"
+          "775",
+          "850"
         ],
         "generated": true
       },
@@ -64887,7 +65171,7 @@
     "img": "/apps/dota2/images/dota_react/abilities/arc_warden_runic_infusion.png"
   },
   "special_bonus_unique_arc_warden": {
-    "dname": "+200 Spark Wraith Damage"
+    "dname": "+240 Spark Wraith Damage"
   },
   "special_bonus_unique_arc_warden_3": {
     "dname": "+25 Magnetic Field Attack Speed"
@@ -64902,10 +65186,10 @@
     "dname": "+30s Spark Wraith Duration"
   },
   "special_bonus_unique_arc_warden_8": {
-    "dname": "+1.5 Runic Infusion All Attributes Bonus"
+    "dname": "+1.0 Runic Infusion All Attributes Bonus"
   },
   "special_bonus_unique_arc_warden_9": {
-    "dname": "-5s Magnetic Field Cooldown"
+    "dname": "-4s Magnetic Field Cooldown"
   },
   "special_bonus_unique_arc_warden_flux_silences": {
     "dname": "Flux Silences when target is alone"
@@ -65882,10 +66166,10 @@
         "key": "impact_movement_slow",
         "header": "MOVEMENT SLOW:",
         "value": [
-          "35%",
+          "30%",
+          "40%",
           "50%",
-          "65%",
-          "80%"
+          "60%"
         ]
       },
       {
@@ -66142,7 +66426,7 @@
       }
     ],
     "mc": "0",
-    "cd": "3",
+    "cd": "5",
     "img": "/apps/dota2/images/dota_react/abilities/monkey_king_transfiguration.png"
   },
   "pangolier_swashbuckle": {
@@ -66253,10 +66537,10 @@
     ],
     "lore": "The Pangolier's blade is even nimbler than his tongue.",
     "mc": [
-      "75",
-      "80",
       "85",
-      "90"
+      "90",
+      "95",
+      "100"
     ],
     "cd": [
       "19",
@@ -66426,10 +66710,10 @@
         "key": "attack_slow",
         "header": "ATTACK SPEED REDUCTION:",
         "value": [
-          "40",
-          "80",
-          "120",
-          "160"
+          "35",
+          "70",
+          "105",
+          "140"
         ]
       },
       {
@@ -66462,7 +66746,7 @@
       {
         "key": "damage_pct",
         "header": "TOTAL ATTACK DAMAGE AS DAMAGE:",
-        "value": "100%"
+        "value": "80%"
       },
       {
         "key": "cast_time_tooltip",
@@ -66566,8 +66850,8 @@
       "150"
     ],
     "cd": [
+      "100",
       "90",
-      "85",
       "80"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/pangolier_gyroshell.png"
@@ -66716,7 +67000,7 @@
       }
     ],
     "lore": "It requires deft tailwork and immense balance to defy momentum in the heart of battle.",
-    "mc": "50",
+    "mc": "75",
     "cd": "40",
     "img": "/apps/dota2/images/dota_react/abilities/pangolier_rollup.png"
   },
@@ -66750,7 +67034,7 @@
     "dname": "+125 Shield Crash Barrier"
   },
   "special_bonus_unique_pangolier_luckyshot_armor": {
-    "dname": "+3 Lucky Shot Armor Reduction"
+    "dname": "+2 Lucky Shot Armor Reduction"
   },
   "special_bonus_unique_pangolier_shield_crash_cooldown": {
     "dname": "-1.5s Shield Crash Cooldown"
@@ -66950,12 +67234,6 @@
         "header": "DAMAGE REDUCTION PCT:",
         "value": "0",
         "generated": true
-      },
-      {
-        "key": "abilitycastrange",
-        "header": "CAST RANGE:",
-        "value": "900",
-        "generated": true
       }
     ],
     "lore": "You'll have to excuse my friend Jex. He's really into murder.",
@@ -66989,9 +67267,9 @@
         "key": "destination_radius",
         "header": "RADIUS:",
         "value": [
-          "400",
           "450",
-          "500"
+          "500",
+          "550"
         ]
       },
       {
@@ -67174,12 +67452,7 @@
       {
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
-        "value": [
-          "600",
-          "625",
-          "650",
-          "675"
-        ],
+        "value": "700",
         "generated": true
       },
       {
@@ -67578,7 +67851,7 @@
       {
         "key": "immunity_resist",
         "header": "IMMUNITY RESIST:",
-        "value": "95",
+        "value": "90",
         "generated": true
       }
     ],
@@ -67964,10 +68237,10 @@
     ],
     "lore": "The legendary Spear of Mars still glows with the heat of the forge god's fires.",
     "mc": [
+      "90",
       "100",
       "110",
-      "120",
-      "130"
+      "120"
     ],
     "cd": [
       "14",
@@ -68068,17 +68341,17 @@
     "dname": "Dauntless",
     "is_innate": true,
     "behavior": "Passive",
-    "desc": "Mars gets more HP Regen the more he is outnumbered by enemy heroes in 700 radius.",
+    "desc": "Mars gets more HP Regen the more he is outnumbered by enemy heroes in 900 radius.",
     "attrib": [
       {
         "key": "health_regen_per_enemy",
         "header": "HP REGEN PER EXTRA ENEMY:",
-        "value": "40%"
+        "value": "50%"
       },
       {
         "key": "radius",
         "header": "RADIUS:",
-        "value": "700",
+        "value": "900",
         "generated": true
       }
     ],
@@ -68206,8 +68479,8 @@
         "header": "SPEAR DAMAGE:",
         "value": [
           "80",
-          "160",
-          "240"
+          "170",
+          "260"
         ]
       },
       {
@@ -68502,10 +68775,10 @@
     ],
     "desc": "Void Spirit temporarily fades into the aether, creating a number of portals through which he can reassemble himself. Upon exiting a portal, he damages all enemies in the area.",
     "dmg": [
-      "120",
-      "200",
-      "280",
-      "360"
+      "105",
+      "185",
+      "265",
+      "345"
     ],
     "attrib": [
       {
@@ -68864,7 +69137,7 @@
       {
         "key": "blast_width_initial",
         "header": "BLAST WIDTH INITIAL:",
-        "value": "225",
+        "value": "250",
         "generated": true
       },
       {
@@ -68926,10 +69199,10 @@
       "100"
     ],
     "cd": [
-      "18",
-      "15",
-      "12",
-      "9"
+      "17",
+      "14",
+      "11",
+      "8"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/snapfire_scatterblast.png"
   },
@@ -69585,7 +69858,7 @@
       {
         "key": "mark_duration",
         "header": "DEBUFF DURATION:",
-        "value": "7"
+        "value": "6"
       },
       {
         "key": "slow_pct",
@@ -69819,9 +70092,9 @@
       "100"
     ],
     "cd": [
+      "19",
       "16",
-      "14",
-      "12",
+      "13",
       "10"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/hoodwink_acorn_shot.png"
@@ -69926,10 +70199,10 @@
         "key": "movement_speed_pct",
         "header": "BONUS MOVEMENT SPEED:",
         "value": [
+          "15%",
           "20%",
           "25%",
-          "30%",
-          "35%"
+          "30%"
         ]
       },
       {
@@ -70383,7 +70656,7 @@
       }
     ],
     "lore": "Across the vast lineage of star progeny, there were multitudes unwilling to align with the aims of the Children of Light. To those who dared organize defiance, the Children would dispatch Valora and her hammer to show a measure of their power--to leave the rebels either shattered or set back to rights.",
-    "mc": "100",
+    "mc": "110",
     "cd": [
       "17",
       "15",
@@ -70679,9 +70952,9 @@
         "key": "land_stun_duration",
         "header": "LANDING STUN DURATION:",
         "value": [
+          "1.2",
           "1.4",
-          "1.6",
-          "1.8"
+          "1.6"
         ]
       },
       {
@@ -70764,7 +71037,7 @@
       {
         "key": "max_dmg_pct",
         "header": "MAX DAMAGE INCREASE:",
-        "value": "10%"
+        "value": "8%"
       },
       {
         "key": "max_vision_pct",
@@ -71349,7 +71622,7 @@
       {
         "key": "abilitycastrange",
         "header": "CAST RANGE:",
-        "value": "500",
+        "value": "600",
         "generated": true
       },
       {
@@ -71360,12 +71633,7 @@
       }
     ],
     "lore": "Marci learned at a young age that the best asset in a scrap is a steady companion.",
-    "mc": [
-      "60",
-      "65",
-      "70",
-      "75"
-    ],
+    "mc": "60",
     "cd": "20",
     "img": "/apps/dota2/images/dota_react/abilities/marci_bodyguard.png"
   },
@@ -71407,7 +71675,7 @@
       }
     ],
     "lore": "Professional courtesy, from one courier to another.",
-    "cd": "245",
+    "cd": "215",
     "img": "/apps/dota2/images/dota_react/abilities/marci_special_delivery.png"
   },
   "special_bonus_unique_marci_grapple_stun_duration": {
@@ -71423,7 +71691,7 @@
     "dname": "+15% Unleash Movement Speed"
   },
   "special_bonus_unique_marci_grapple_damage": {
-    "dname": "+100 Dispose Damage"
+    "dname": "+115 Dispose Damage"
   },
   "special_bonus_unique_marci_unleash_extend_duration": {
     "dname": "Unleash Duration Extended By 6s On Kill"
@@ -71573,7 +71841,7 @@
       {
         "key": "effect_radius",
         "header": "DAMAGE AOE:",
-        "value": "230"
+        "value": "200"
       },
       {
         "key": "step_distance",
@@ -71820,9 +72088,9 @@
     "lore": "Though none are certain whether his utterances have true meaning, most concede the Beast's powerful grip and tendency to smash his enemies into naught but pulp and pieces communicates his intent well enough.",
     "mc": "100",
     "cd": [
+      "45",
       "40",
-      "35",
-      "30"
+      "35"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/primal_beast_pulverize.png"
   },
@@ -71945,6 +72213,12 @@
         "key": "trample_bonus",
         "header": "TRAMPLE BONUS:",
         "value": "0",
+        "generated": true
+      },
+      {
+        "key": "model_scale_per_stack",
+        "header": "MODEL SCALE PER STACK:",
+        "value": "1.1",
         "generated": true
       }
     ],
@@ -72248,7 +72522,12 @@
       "165",
       "180"
     ],
-    "cd": "30",
+    "cd": [
+      "30",
+      "28",
+      "26",
+      "24"
+    ],
     "img": "/apps/dota2/images/dota_react/abilities/muerta_the_calling.png"
   },
   "muerta_gunslinger": {
@@ -72311,7 +72590,11 @@
       {
         "key": "base_damage_percent",
         "header": "BASE DAMAGE PERCENT:",
-        "value": "75",
+        "value": [
+          "70",
+          "85",
+          "100"
+        ],
         "generated": true
       },
       {
@@ -72399,6 +72682,12 @@
         "key": "spell_amp_per_stack",
         "header": "SPELL AMP PER STACK:",
         "value": "1",
+        "generated": true
+      },
+      {
+        "key": "max_stacks",
+        "header": "MAX STACKS:",
+        "value": "5",
         "generated": true
       }
     ],
@@ -73253,7 +73542,7 @@
       "No Target",
       "Hidden"
     ],
-    "desc": "Use: Proportion Distortion Creates 1 imperfect image of your hero that lasts 18 seconds. Your illusion deals 28% and takes 300% damage.",
+    "desc": "Use: Proportion Distortion Creates 1 imperfect image of your hero that lasts 18 seconds. Your illusion deals 100% and takes 300% damage.",
     "attrib": [
       {
         "key": "images_count",
@@ -73294,13 +73583,13 @@
       {
         "key": "images_do_damage_percent_ranged",
         "header": "IMAGES DO DAMAGE PERCENT RANGED:",
-        "value": "-72",
+        "value": "-0",
         "generated": true
       },
       {
         "key": "tooltip_damage_outgoing_ranged",
         "header": "TOOLTIP DAMAGE OUTGOING RANGED:",
-        "value": "28",
+        "value": "100",
         "generated": true
       },
       {
@@ -73786,7 +74075,7 @@
     "dname": "+75/+300 Tame the Beasts Min/Max Damage"
   },
   "special_bonus_unique_ringmaster_wheel_radius": {
-    "dname": "+100 Wheel Radius and Range"
+    "dname": "+150 Wheel of Wonder Radius and Range"
   },
   "special_bonus_unique_ringmaster_whip_debuff_immunity": {
     "dname": "Debuff Immunity While Channeling Tame the Beasts"
@@ -73827,7 +74116,7 @@
       {
         "key": "katana_agility_bonus_base_damage",
         "header": "KATANA BONUS AGILITY BASE DAMAGE:",
-        "value": "16%"
+        "value": "12%"
       },
       {
         "key": "katana_swap_bonus_damage",
@@ -73885,7 +74174,7 @@
       "Hero",
       "Basic"
     ],
-    "desc": "Kez slashes forward in a 800 distance line with his Katana, attacking enemies in an area and applying a brief 100s impact slow. After a short delay, the area is attacked again. Heroes take bonus damage.",
+    "desc": "Kez slashes forward in a 800 distance line with his Katana, attacking enemies in an area and applying a brief 100% impact slow. After a short delay, the area is attacked again. Heroes take bonus damage.",
     "attrib": [
       {
         "key": "katana_echo_damage",
@@ -74138,10 +74427,10 @@
     "lore": "To fight back against the reach of Imperia and her Queensguard, the Kazurai had to become skilled in the ways of attrition.",
     "mc": "40",
     "cd": [
-      "20",
-      "15",
-      "10",
-      "5"
+      "24",
+      "18",
+      "12",
+      "6"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/kez_kazurai_katana.png"
   },
@@ -74180,9 +74469,9 @@
         "key": "base_damage",
         "header": "BASE DAMAGE:",
         "value": [
-          "30",
-          "60",
-          "90"
+          "40",
+          "70",
+          "100"
         ]
       },
       {
@@ -74447,7 +74736,7 @@
     ],
     "bkbpierce": "Yes",
     "dispellable": "Strong Dispels Only",
-    "desc": "Kez has a chance to critically strike the target when attacking with Sais.\n\nKez may activate the ability to disarm himself, lock his facing, and parry attacks and attack effects from the targeted direction for 2 seconds. If an attack is parried from an enemy Hero in this way, that Hero is stunned for 0.4s and gains a Mark. When a Marked target is attacked by Kez, it will guarantee a critical strike and stun the target.\n\nThe sub-ability may be used to cancel the blocking early.",
+    "desc": "Kez has a chance to critically strike the target when attacking with Sais.\n\nKez may activate the ability to disarm himself, lock his facing, and parry attacks and attack effects from the targeted direction for 1.5 seconds. If an attack is parried from an enemy Hero in this way, that Hero is stunned for 0.4s and gains a Mark. When a Marked target is attacked by Kez, it will guarantee a critical strike and stun the target.\n\nThe sub-ability may be used to cancel the blocking early.",
     "attrib": [
       {
         "key": "sai_proc_vuln_chance",
@@ -74494,7 +74783,7 @@
       {
         "key": "parry_duration",
         "header": "PARRY DURATION:",
-        "value": "2",
+        "value": "1.5",
         "generated": true
       },
       {
@@ -74528,10 +74817,10 @@
       "0"
     ],
     "cd": [
-      "20",
-      "15",
-      "10",
-      "5"
+      "24",
+      "18",
+      "12",
+      "6"
     ],
     "img": "/apps/dota2/images/dota_react/abilities/kez_shodo_sai.png"
   },
@@ -74581,9 +74870,9 @@
         "key": "buff_duration",
         "header": "BUFF DURATION:",
         "value": [
-          "7",
           "8",
-          "9"
+          "10",
+          "12"
         ]
       },
       {
@@ -74841,9 +75130,9 @@
     ],
     "lore": "'Hey, when a beach brawl breaks out, you gotta learn to throw your musical weight around or the party's over proper quick.'",
     "mc": [
-      "20",
-      "32",
-      "44"
+      "25",
+      "35",
+      "45"
     ],
     "cd": "0.2",
     "img": "/apps/dota2/images/dota_react/abilities/largo_song_fight_song.png"
@@ -74916,9 +75205,9 @@
     ],
     "lore": "'It's like that old story about the scary swamp witch. You better watch just where you're jumping when you're trying to do it lickety-split.'",
     "mc": [
-      "20",
-      "32",
-      "44"
+      "25",
+      "35",
+      "45"
     ],
     "cd": "0.2",
     "img": "/apps/dota2/images/dota_react/abilities/largo_song_double_time.png"
@@ -74972,9 +75261,9 @@
     ],
     "lore": "'If this song can heal an ageless isaloth, it can handle a few cuts and bruises on the lot of you.'",
     "mc": [
-      "20",
-      "32",
-      "44"
+      "25",
+      "35",
+      "45"
     ],
     "cd": "0.2",
     "img": "/apps/dota2/images/dota_react/abilities/largo_song_good_vibrations.png"
@@ -75127,9 +75416,9 @@
         "key": "duration",
         "header": "BUFF DURATION:",
         "value": [
-          "12",
-          "18",
-          "24",
+          "15",
+          "20",
+          "25",
           "30"
         ]
       },
@@ -75171,12 +75460,7 @@
       }
     ],
     "lore": "Largo loves to help his friends find glory through the power of music, never missing a chance at a killer duet.",
-    "mc": [
-      "25",
-      "35",
-      "45",
-      "55"
-    ],
+    "mc": "40",
     "cd": "25",
     "img": "/apps/dota2/images/dota_react/abilities/largo_croak_of_genius.png"
   },
@@ -75290,7 +75574,7 @@
       {
         "key": "buff_amplification",
         "header": "BONUS DURATION:",
-        "value": "9%"
+        "value": "15%"
       },
       {
         "key": "repeat_buff",
@@ -75302,22 +75586,22 @@
     "img": "/apps/dota2/images/dota_react/abilities/largo_encore.png"
   },
   "special_bonus_unique_mirana_quiver_damage": {
-    "dname": "+{s:bonus_bonus_damage} Celestial Quiver Damage"
+    "dname": "+50 Celestial Quiver Damage"
   },
   "special_bonus_unique_broodmother_web_speed": {
-    "dname": "+{s:bonus_bonus_movespeed}% Spin Web Move Speed and Ignore Speed Limit"
+    "dname": "+7% Spin Web Move Speed and Ignore Speed Limit"
   },
   "special_bonus_unique_spectre_haunt_cooldown": {
     "dname": "-{s:bonus_AbilityCooldown}s Haunt Cooldown"
   },
   "special_bonus_unique_spectre_shadow_step_duration": {
-    "dname": "+{s:bonus_duration}s Shadow Step Duration"
+    "dname": "+1.0s Shadow Step Duration"
   },
   "special_bonus_unique_ancient_apparition_cold_feet_dps": {
-    "dname": "+{s:bonus_damage_per_second} Cold Feet Damage Per Second"
+    "dname": "+30 Cold Feet Damage Per Second"
   },
   "special_bonus_unique_invoker_chaos_meteor_size": {
-    "dname": "+{s:bonus_area_of_effect} Chaos Meteor Radius"
+    "dname": "+25 Chaos Meteor Radius"
   },
   "special_bonus_unique_invoker_cold_snap_heal": {
     "dname": "Cold Snap Trigger Heals"
@@ -75332,16 +75616,16 @@
     "dname": "+{s:bonus_int_steal} Glaives of Wisdom Intelligence Steal"
   },
   "special_bonus_unique_silencer_global_duration": {
-    "dname": "+{s:bonus_AbilityDuration}s Global Silence Duration"
+    "dname": "+2s Global Silence Duration"
   },
   "special_bonus_unique_brewmaster_thunder_clap_damage": {
-    "dname": "+{s:bonus_damage} Thunder Clap Damage"
+    "dname": "+160 Thunder Clap Damage"
   },
   "special_bonus_unique_brewmaster_drunken_brawler_stance_bonus": {
-    "dname": "{s:bonus_stance_multiplier_tooltip}x Drunken Brawler Stance Bonuses"
+    "dname": "1.5x Drunken Brawler Stance Bonuses"
   },
   "special_bonus_unique_brewmaster_brewed_up_duration": {
-    "dname": "+{s:bonus_brewed_up_duration}/{s:bonus_brewed_up_duration_extend}s Drunken Brawler Brew Up / Extend Duration"
+    "dname": "+2/1s Drunken Brawler Brew Up / Extend Duration"
   },
   "special_bonus_unique_brewmaster_primal_split_duration": {
     "dname": "+{s:bonus_duration}s Primal Split Duration"
@@ -75350,46 +75634,46 @@
     "dname": "+{s:bonus_attack_damage_reduction}% Fade Bolt Attack Damage Steal"
   },
   "special_bonus_unique_rubick_arcane_supremacy": {
-    "dname": "+{s:bonus_spell_amp}% Arcane Supremacy Spell Amplification"
+    "dname": "+7% Arcane Supremacy Spell Amplification"
   },
   "special_bonus_unique_rubick_fade_bolt_spell_reduction": {
-    "dname": "+{s:bonus_damage_reduction}% Fade Bolt Damage Reduction"
+    "dname": "+12% Fade Bolt Damage Reduction"
   },
   "special_bonus_unique_rubick_curiosity_factor": {
-    "dname": "{s:bonus_curiosity_factor}x Curiosity Bonuses"
+    "dname": "1.5x Curiosity Bonuses"
   },
   "special_bonus_unique_mars_spear_stun_duration": {
-    "dname": "+{s:bonus_stun_duration}s Spear of Mars Stun"
+    "dname": "+0.5s Spear of Mars Stun"
   },
   "special_bonus_unique_mars_spear_bonus_damage": {
-    "dname": "+{s:bonus_damage} Spear Of Mars Damage"
+    "dname": "+100 Spear Of Mars Damage"
   },
   "special_bonus_unique_mars_arena_of_blood_hp_regen": {
-    "dname": "Arena Of Blood Grants Team +{s:bonus_health_regen} HP Regen"
+    "dname": "Arena Of Blood Grants Team +180 HP Regen"
   },
   "special_bonus_unique_mars_gods_rebuke_extra_crit": {
-    "dname": "God's Rebuke +{s:bonus_crit_mult}% Crit"
+    "dname": "God's Rebuke +65% Crit"
   },
   "special_bonus_unique_mars_spear_cooldown": {
     "dname": "-{s:value}s Spear Cooldown"
   },
   "special_bonus_unique_mars_rebuke_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s God's Rebuke Cooldown"
+    "dname": "-2.5s God's Rebuke Cooldown"
   },
   "special_bonus_unique_mars_rebuke_slow": {
     "dname": "+{s:bonus_knockback_slow_duration}s God's Rebuke Slow"
   },
   "special_bonus_unique_mars_rebuke_radius": {
-    "dname": "+{s:bonus_radius} God's Rebuke Distance"
+    "dname": "+100 God's Rebuke Distance"
   },
   "special_bonus_unique_mars_bulwark_speed": {
     "dname": "-{s:bonus_redirect_speed_penatly}% Bulwark Movespeed Penalty"
   },
   "special_bonus_unique_mars_bulwark_damage_reduction": {
-    "dname": "+{s:bonus_physical_damage_reduction}%/+{s:bonus_physical_damage_reduction_side}% Bulwark Front/Side damage reduction"
+    "dname": "+10%/+5% Bulwark Front/Side damage reduction"
   },
   "special_bonus_unique_mars_bulwark_redirect_chance": {
-    "dname": "+{s:bonus_redirect_chance}% Bulwark Active Redirect Chance"
+    "dname": "+30% Bulwark Active Redirect Chance"
   },
   "special_bonus_unique_mars_bulwark_cooldown": {
     "dname": "-{s:bonus_AbilityCooldown}s Bulwark Cooldown"
@@ -75398,25 +75682,25 @@
     "dname": "-{s:bonus_AbilityCooldown}s Arena Of Blood Cooldown"
   },
   "special_bonus_unique_mars_arena_of_blood_damage": {
-    "dname": "+{s:bonus_spear_damage} Arena Of Blood Spear Damage"
+    "dname": "+70 Arena Of Blood Spear Damage"
   },
   "special_bonus_unique_mars_bulwark_forced_movement_immunity": {
     "dname": "Bulwark Grants Immunity to Forced Movement"
   },
   "special_bonus_unique_mars_dauntless_hpregen": {
-    "dname": "+{s:bonus_health_regen_per_enemy}% Dauntless Regen Per Enemy"
+    "dname": "+10% Dauntless Regen Per Enemy"
   },
   "special_bonus_unique_void_spirit_1": {
-    "dname": "-{s:bonus_AbilityChargeRestoreTime}s Astral Step Charge Restore Time"
+    "dname": "-3s Astral Step Charge Restore Time"
   },
   "special_bonus_unique_void_spirit_2": {
-    "dname": "+{s:bonus_impact_damage} Aether Remnant Damage"
+    "dname": "+65 Aether Remnant Damage"
   },
   "special_bonus_unique_void_spirit_3": {
-    "dname": "Dissimilate Roots for {s:bonus_root_duration}s"
+    "dname": "Dissimilate Roots for 2s"
   },
   "special_bonus_unique_void_spirit_4": {
-    "dname": "+{s:bonus_damage} Resonant Pulse Damage"
+    "dname": "+40 Resonant Pulse Damage"
   },
   "special_bonus_unique_void_spirit_5": {
     "dname": "{s:value}% Larger Dissimilate Portals"
@@ -75428,7 +75712,7 @@
     "dname": "Remnant Provides {s:value} True Sight"
   },
   "special_bonus_unique_void_spirit_8": {
-    "dname": "{s:bonus_crit_damage}% Astral Step Crit"
+    "dname": "140% Astral Step Crit"
   },
   "special_bonus_unique_void_spirit_9": {
     "dname": "+{s:value} Astral Step Charges"
@@ -75437,37 +75721,37 @@
     "dname": "Outer Dissimilate Ring"
   },
   "special_bonus_unique_void_spirit_resonant_pulse_barrier": {
-    "dname": "+{s:bonus_base_absorb_amount}% Resonant Pulse Barrier"
+    "dname": "+20% Resonant Pulse Barrier"
   },
   "special_bonus_unique_snapfire_1": {
-    "dname": "+{s:bonus_projectile_count} Mortimer Kisses Launched"
+    "dname": "+8 Mortimer Kisses Launched"
   },
   "special_bonus_unique_snapfire_2": {
-    "dname": "+{s:bonus_buffed_attacks} Lil' Shredder attacks"
+    "dname": "+2 Lil' Shredder attacks"
   },
   "special_bonus_unique_snapfire_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Firesnap Cookie Cooldown"
+    "dname": "-3s Firesnap Cookie Cooldown"
   },
   "special_bonus_unique_snapfire_5": {
-    "dname": "+{s:bonus_burn_damage} Mortimer Kisses Burn DPS"
+    "dname": "+35 Mortimer Kisses Burn DPS"
   },
   "special_bonus_unique_snapfire_6": {
-    "dname": "+{s:bonus_damage_pct}% Lil' Shredder Attack Damage"
+    "dname": "+60% Lil' Shredder Attack Damage"
   },
   "special_bonus_unique_snapfire_7": {
-    "dname": "+{s:bonus_damage} Scatterblast Damage"
+    "dname": "+70 Scatterblast Damage"
   },
   "special_bonus_unique_snapfire_8": {
-    "dname": "+{s:bonus_extra_targets} Lil' Shredder Targets"
+    "dname": "+=2 Lil' Shredder Targets"
   },
   "special_bonus_unique_snapfire_mortimer_kisses_impact_damage": {
     "dname": "+{s:bonus_damage_per_impact} Mortimer Kisses Impact Damage"
   },
   "special_bonus_unique_snapfire_firesnap_cookie_additional_charge": {
-    "dname": "{s:bonus_AbilityCharges} Firesnap Cookie Charges"
+    "dname": "2 Firesnap Cookie Charges"
   },
   "special_bonus_unique_hoodwink_acorn_shot_charges": {
-    "dname": "{s:bonus_AbilityCharges} Acorn Shot Charges"
+    "dname": "2 Acorn Shot Charges"
   },
   "special_bonus_unique_hoodwink_sharpshooter_speed": {
     "dname": "{s:pct_change}% Sharpshooter Faster Projectile / Charge Time"
@@ -75479,28 +75763,28 @@
     "dname": "+{s:bonus_trap_radius} Bushwhack Radius"
   },
   "special_bonus_unique_hoodwink_bushwhack_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Bushwhack Cooldown"
+    "dname": "-2s Bushwhack Cooldown"
   },
   "special_bonus_unique_hoodwink_camouflage": {
     "dname": "Scurry Camouflage"
   },
   "special_bonus_unique_hoodwink_bushwhack_damage": {
-    "dname": "+{s:bonus_total_damage} Bushwhack Damage"
+    "dname": "+50 Bushwhack Damage"
   },
   "special_bonus_unique_hoodwink_scurry_duration": {
-    "dname": "+{s:bonus_duration}s Scurry Duration"
+    "dname": "+1s Scurry Duration"
   },
   "special_bonus_unique_hoodwink_acorn_shot_bounces": {
-    "dname": "+{s:bonus_bounce_count} Acorn Shot Bounces"
+    "dname": "+2 Acorn Shot Bounces"
   },
   "special_bonus_unique_hoodwink_scurry_evasion": {
     "dname": "+{s:bonus_bonus_active_evasion}% Scurry Evasion When Active"
   },
   "special_bonus_unique_hoodwink_sharpshooter_damage": {
-    "dname": "+{s:bonus_max_damage} Sharpshooter Max Damage"
+    "dname": "+400 Sharpshooter Max Damage"
   },
   "special_bonus_unique_hoodwink_scurry_charges": {
-    "dname": "+{s:bonus_AbilityCharges} Scurry Ability Charge"
+    "dname": "+1 Scurry Ability Charge"
   },
   "special_bonus_unique_hoodwink_sharpshooter_vision": {
     "dname": "Sharpshooter Provides Vision While Charging"
@@ -75539,28 +75823,28 @@
     "dname": "+{s:bonus_damage} Dead Shot Damage"
   },
   "special_bonus_unique_muerta_dead_shot_range": {
-    "dname": "+{s:bonus_AbilityCastRange} Dead Shot Cast Range"
+    "dname": "+300 Dead Shot Cast Range"
   },
   "special_bonus_unique_muerta_the_calling_num_revenants": {
-    "dname": "The Calling summons {s:bonus_num_revenants} additional revenants"
+    "dname": "The Calling summons 2 additional revenants"
   },
   "special_bonus_unique_muerta_calling_hp_regen": {
-    "dname": "+{s:bonus_hp_regen_pct}% Max HP Regen while inside The Calling"
+    "dname": "+3.0% Max HP Regen while inside The Calling"
   },
   "special_bonus_unique_kez_falcon_rush_duration": {
-    "dname": "+{s:bonus_duration}s Falcon Rush Duration"
+    "dname": "+2.0s Falcon Rush Duration"
   },
   "special_bonus_unique_kez_kazura_katana_bleed_damage": {
-    "dname": "+{s:bonus_katana_bleed_attack_damage_pct}% Kazurai Katana Damage Per Second"
+    "dname": "+4.0% Kazurai Katana Damage Per Second"
   },
   "special_bonus_unique_kez_echo_slash_strike_count": {
-    "dname": "+{s:bonus_katana_strikes} Echo Slash Attack"
+    "dname": "+1 Echo Slash Attack"
   },
   "special_bonus_unique_kez_mark_damage": {
-    "dname": "+{s:bonus_base_crit_pct}% Shodo Sai Critical Strike"
+    "dname": "+80% Shodo Sai Critical Strike"
   },
   "special_bonus_unique_kez_raptor_dance_radius": {
-    "dname": "+{s:bonus_radius} Raptor Dance Radius"
+    "dname": "+50 Raptor Dance Radius"
   },
   "special_bonus_unique_kez_grapple_cast_range": {
     "dname": "+{s:bonus_AbilityCastRange} Grappling Claw Cast Range"
@@ -75578,7 +75862,7 @@
     "dname": "+{s:bonus_buff_evasion_pct}% Falcon Rush Evasion"
   },
   "special_bonus_unique_kez_raptor_dance_strikes": {
-    "dname": "+{s:bonus_strikes} Raptor Dance Strike"
+    "dname": "+1 Raptor Dance Strike"
   },
   "special_bonus_unique_kez_ravens_veil_mark_parry_bonus": {
     "dname": "Raven's Veil Mark Applies Parry Bonus"
@@ -75590,7 +75874,7 @@
     "dname": "Add {s:bonus_attack_factor}% of Attack Damage to Talon Toss"
   },
   "special_bonus_unique_kez_falcon_rush_attack_speed": {
-    "dname": "{s:bonus_bonus_attack_speed} Bonus Attack Speed During Falcon Rush"
+    "dname": "=40 Bonus Attack Speed During Falcon Rush"
   },
   "special_bonus_unique_kez_falcon_rush_damage": {
     "dname": "+{s:bonus_base_echo_damage}% Falcon Rush Echo Damage"
@@ -75598,59 +75882,62 @@
   "special_bonus_unique_kez_ravens_dispel": {
     "dname": "Raven's Veil Applies Basic Dispel"
   },
+  "special_bonus_unique_kez_switch_weapons_swap_bonus": {
+    "dname": "+6% Switch Discipline Swap Bonuses"
+  },
   "special_bonus_unique_clockwerk": {
-    "dname": "-{s:bonus_interval}s Battery Assault Interval"
+    "dname": "-0.25s Battery Assault Interval"
   },
   "special_bonus_unique_clockwerk_2": {
-    "dname": "+{s:bonus_mana_burn} Power Cogs Mana Burn"
+    "dname": "+80 Power Cogs Mana Burn"
   },
   "special_bonus_unique_clockwerk_3": {
-    "dname": "+{s:bonus_damage} Battery Assault Damage"
+    "dname": "+25 Battery Assault Damage"
   },
   "special_bonus_unique_clockwerk_4": {
     "dname": "Rocket Flare True Sight"
   },
   "special_bonus_unique_clockwerk_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Hookshot Cooldown"
+    "dname": "-8s Hookshot Cooldown"
   },
   "special_bonus_unique_clockwerk_6": {
     "dname": "Debuff Immunity Inside Power Cogs"
   },
   "special_bonus_unique_clockwerk_7": {
-    "dname": "+{s:bonus_slow_duration}s Rocket Flare Slow Duration"
+    "dname": "+0.4s Rocket Flare Slow Duration"
   },
   "special_bonus_unique_clockwerk_8": {
     "dname": "+{s:bonus_mana_burn} Power Cogs Mana Burn"
   },
   "special_bonus_unique_clockwerk_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Power Cogs Cooldown"
+    "dname": "-2s Power Cogs Cooldown"
   },
   "special_bonus_unique_clockwerk_flare_damage": {
     "dname": "+{s:bonus_damage} Rocket Flare Damage"
   },
   "special_bonus_unique_clockwerk_hookshot_damage": {
-    "dname": "+{s:bonus_damage} Hookshot Damage"
+    "dname": "+75 Hookshot Damage"
   },
   "special_bonus_unique_clockwerk_rocket_flare_charges": {
-    "dname": "{s:bonus_AbilityCharges} Rocket Flare Charges"
+    "dname": "3 Rocket Flare Charges"
   },
   "special_bonus_unique_omniknight_degen_aura_radius": {
-    "dname": "+{s:bonus_radius} Degen Aura Radius"
+    "dname": "+150 Degen Aura Radius"
   },
   "special_bonus_unique_centaur_1": {
     "dname": "Gains Retaliate Aura"
   },
   "special_bonus_unique_centaur_2": {
-    "dname": "+{s:bonus_stun_duration}s Hoof Stomp Duration"
+    "dname": "+1.0s Hoof Stomp Duration"
   },
   "special_bonus_unique_centaur_3": {
-    "dname": "+{s:bonus_return_damage} Retaliate Damage"
+    "dname": "+45 Retaliate Damage"
   },
   "special_bonus_unique_centaur_4": {
-    "dname": "+{s:bonus_strength_damage}% Double Edge Strength Damage"
+    "dname": "+30% Double Edge Strength Damage"
   },
   "special_bonus_unique_centaur_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Stampede Cooldown"
+    "dname": "-25s Stampede Cooldown"
   },
   "special_bonus_unique_centaur_6": {
     "dname": "+{s:value}% Stampede Damage Reduction"
@@ -75662,109 +75949,109 @@
     "dname": "+{s:bonus_bonus_attack_range} Death Ward Attack Range"
   },
   "special_bonus_unique_witch_doctor_2": {
-    "dname": "+{s:bonus_bonus_heal_percent}% Target Max Health Voodoo Restoration Heal"
+    "dname": "+1% Target Max Health Voodoo Restoration Heal"
   },
   "special_bonus_unique_witch_doctor_2_facet_witch_doctor_voodoo_festeration": {
     "dname": "+{s:bonus_bonus_heal_percent}% Target Max Health Voodoo Restoration Damage"
   },
   "special_bonus_unique_witch_doctor_3": {
-    "dname": "+{s:bonus_bounces} Paralyzing Cask Bounces"
+    "dname": "+6 Paralyzing Cask Bounces"
   },
   "special_bonus_unique_witch_doctor_4": {
-    "dname": "-{s:bonus_tooltip_mana_per_second}% Voodoo Restoration Mana Per Second"
+    "dname": "-25% Voodoo Restoration Mana Per Second"
   },
   "special_bonus_unique_witch_doctor_5": {
-    "dname": "+{s:bonus_damage} Death Ward Damage"
+    "dname": "+40 Death Ward Damage"
   },
   "special_bonus_unique_witch_doctor_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Paralyzing Cask Cooldown"
+    "dname": "-3.0s Paralyzing Cask Cooldown"
   },
   "special_bonus_unique_witch_doctor_7": {
-    "dname": "+{s:bonus_AbilityDuration}s Maledict Duration"
+    "dname": "+4s Maledict Duration"
   },
   "special_bonus_unique_witch_doctor_maledict_spread": {
-    "dname": "Maledict bursts deal {s:bonus_spread_pct}% damage in a {s:bonus_spread_radius} AoE "
+    "dname": "Maledict bursts deal 75% damage in a 800 AoE "
   },
   "special_bonus_unique_necrophos": {
-    "dname": "-{s:bonus_AbilityCooldown}s Death Pulse Cooldown"
+    "dname": "-2.5s Death Pulse Cooldown"
   },
   "special_bonus_unique_necrophos_2": {
-    "dname": "+{s:bonus_aura_damage}% Heartstopper Aura Damage"
+    "dname": "+0.5% Heartstopper Aura Damage"
   },
   "special_bonus_unique_necrophos_3": {
-    "dname": "+{s:bonus_movement_speed}% Ghost Shroud Movement Slow"
+    "dname": "+15% Ghost Shroud Movement Slow"
   },
   "special_bonus_unique_necrophos_4": {
-    "dname": "+{s:bonus_heal} Death Pulse Heal"
+    "dname": "+60 Death Pulse Heal"
   },
   "special_bonus_unique_necrophos_5": {
-    "dname": "+{s:bonus_heal_reduction_pct}% Heartstopper Regen Reduction"
+    "dname": "+20% Heartstopper Regen Reduction"
   },
   "special_bonus_unique_necrophos_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Ghost Shroud Cooldown"
+    "dname": "-2.5s Ghost Shroud Cooldown"
   },
   "special_bonus_unique_necrophos_heartstopper_regen_duration": {
-    "dname": "+{s:bonus_regen_duration}s Sadist Stack Duration"
+    "dname": "+2s Sadist Stack Duration"
   },
   "special_bonus_unique_necrophos_sadist_heal_bonus": {
     "dname": "+{s:bonus_heal_bonus}% Ghost Shroud Self Restoration Amp"
   },
   "special_bonus_unique_necrophos_reaper_scythe_damage_per_health": {
-    "dname": "+{s:bonus_damage_per_health} Reaper's Scythe Damage Per Missing HP"
+    "dname": "+0.3 Reaper's Scythe Damage Per Missing HP"
   },
   "special_bonus_unique_queen_of_pain": {
     "dname": "{s:value} AoE Shadow Strike"
   },
   "special_bonus_unique_queen_of_pain_1": {
-    "dname": "+{s:bonus_attack_speed} Attack Speed against Shadow Striked units"
+    "dname": "+35 Attack Speed against Shadow Striked units"
   },
   "special_bonus_unique_queen_of_pain_2": {
-    "dname": "+{s:bonus_damage} Scream of Pain Damage"
+    "dname": "+115 Scream of Pain Damage"
   },
   "special_bonus_unique_queen_of_pain_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Sonic Wave Cooldown"
+    "dname": "-45s Sonic Wave Cooldown"
   },
   "special_bonus_unique_queen_of_pain_4": {
-    "dname": "-{s:bonus_damage_interval}s Shadow Strike Damage Interval"
+    "dname": "-1s Shadow Strike Damage Interval"
   },
   "special_bonus_unique_queen_of_pain_5": {
     "dname": "-{s:bonus_AbilityCooldown}s Scream of Pain Cooldown"
   },
   "special_bonus_unique_queen_of_pain_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Blink Cooldown"
+    "dname": "-2s Blink Cooldown"
   },
   "special_bonus_unique_queen_of_pain_7": {
-    "dname": "+{s:bonus_damage} Sonic Wave Damage"
+    "dname": "+250 Sonic Wave Damage"
   },
   "special_bonus_unique_queen_of_pain_strike_heal": {
     "dname": "+{s:bonus_duration_heal} Shadow Strike Heal Per Tick"
   },
   "special_bonus_unique_antimage": {
-    "dname": "-{s:bonus_AbilityCooldown}s Blink Cooldown"
+    "dname": "-1s Blink Cooldown"
   },
   "special_bonus_unique_antimage_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Mana Void Cooldown"
+    "dname": "-50s Mana Void Cooldown"
   },
   "special_bonus_unique_antimage_3": {
-    "dname": "+{s:bonus_AbilityCastRange} Blink Cast Range"
+    "dname": "+125 Blink Cast Range"
   },
   "special_bonus_unique_antimage_4": {
     "dname": "+{s:bonus_magic_resistance}% Counterspell Magic Resistance"
   },
   "special_bonus_unique_antimage_5": {
-    "dname": "+{s:bonus_move_slow_min}%/{s:bonus_move_slow_max}% Persecutor Min/Max Movement Slow"
+    "dname": "+9%/18% Persecutor Min/Max Movement Slow"
   },
   "special_bonus_unique_antimage_6": {
-    "dname": "+{s:bonus_mana_void_damage_per_mana} Mana Void Damage Multiplier"
+    "dname": "+0.2 Mana Void Damage Multiplier"
   },
   "special_bonus_unique_antimage_7": {
     "dname": "+{s:bonus_mana_per_hit_pct}% Max Mana Mana Burn"
   },
   "special_bonus_unique_antimage_8": {
-    "dname": "+{s:bonus_mana_void_ministun}s Mana Void Stun"
+    "dname": "+0.8s Mana Void Stun"
   },
   "special_bonus_unique_antimage_manavoid_aoe": {
-    "dname": "+{s:bonus_mana_void_aoe_radius} Mana Void Radius"
+    "dname": "+200 Mana Void Radius"
   },
   "special_bonus_unique_mirana_4_facet_mirana_sunlight": {
     "dname": "-{s:bonus_AbilityCooldown}s Solar Flare Cooldown"
@@ -75773,19 +76060,19 @@
     "dname": "Solar Flare gives +{s:bonus_evasion}% Evasion"
   },
   "special_bonus_unique_bounty_hunter": {
-    "dname": "+{s:bonus_gold_steal} Jinada Gold Steal"
+    "dname": "+50 Jinada Gold Steal"
   },
   "special_bonus_unique_bounty_hunter_2": {
-    "dname": "+{s:bonus_bonus_damage} Shuriken Toss Damage"
+    "dname": "+250 Shuriken Toss Damage"
   },
   "special_bonus_unique_bounty_hunter_3": {
-    "dname": "+{s:bonus_bonus_gold} Track Gold"
+    "dname": "+50 Track Gold"
   },
   "special_bonus_unique_bounty_hunter_4": {
     "dname": "+{s:bonus_bonus_damage} Jinada Damage"
   },
   "special_bonus_unique_bounty_hunter_5": {
-    "dname": "+{s:bonus_slow_duration}s Shuriken Toss Slow"
+    "dname": "+0.6s Shuriken Toss Slow"
   },
   "special_bonus_unique_bounty_hunter_6": {
     "dname": "Half Track Bonus Speed to Allies"
@@ -75797,55 +76084,55 @@
     "dname": "Track Grants Shared Vision"
   },
   "special_bonus_unique_bounty_hunter_9": {
-    "dname": "-{s:bonus_damage_reduction_pct}% Damage Taken in Shadow Walk"
+    "dname": "-30% Damage Taken in Shadow Walk"
   },
   "special_bonus_unique_bounty_hunter_jinada_no_cooldown": {
     "dname": "No Cooldown on Jinada"
   },
   "special_bonus_unique_underlord": {
-    "dname": "+{s:bonus_ensnare_duration}s Pit of Malice Root"
+    "dname": "+0.4s Pit of Malice Root"
   },
   "special_bonus_unique_underlord_2": {
     "dname": "+{s:value} Firestorm Wave Damage"
   },
   "special_bonus_unique_underlord_3": {
-    "dname": "+{s:bonus_damage_reduction_pct}% Atrophy Aura Attack Damage Reduction/Gain"
+    "dname": "+10% Atrophy Aura Attack Damage Reduction/Gain"
   },
   "special_bonus_unique_underlord_4": {
-    "dname": "+{s:bonus_burn_damage}% Firestorm Burn Damage"
+    "dname": "+0.6% Firestorm Burn Damage"
   },
   "special_bonus_unique_underlord_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Firestorm Cooldown"
+    "dname": "-5s Firestorm Cooldown"
   },
   "special_bonus_unique_underlord_6": {
-    "dname": "Pit of Malice Slows by {s:bonus_speed_bonus}%"
+    "dname": "Pit of Malice Slows by 20%"
   },
   "special_bonus_unique_underlord_7": {
-    "dname": "+{s:bonus_bonus_ms}% Invading Force Movement Bonus/Damage Reduction"
+    "dname": "+5% Invading Force Movement Bonus/Damage Reduction"
   },
   "special_bonus_unique_underlord_8": {
-    "dname": "+{s:bonus_bonus_damage_duration}s Atrophy Aura Duration"
+    "dname": "+15s Atrophy Aura Duration"
   },
   "special_bonus_unique_underlord_9": {
-    "dname": "{s:bonus_dps} DPS in {s:bonus_radius} Radius Around Fiend's Gate"
+    "dname": "160 DPS in 700 Radius Around Fiend's Gate"
   },
   "special_bonus_unique_pudge_1": {
-    "dname": "{s:bonus_flesh_heap_strength_buff_amount}x Flesh Heap and Meat Shield bonuses"
+    "dname": "1.5x Flesh Heap and Meat Shield bonuses"
   },
   "special_bonus_unique_pudge_2": {
     "dname": "+{s:value} Rot Damage"
   },
   "special_bonus_unique_pudge_3": {
-    "dname": "{s:bonus_dismember_damage}x Dismember Damage/Heal"
+    "dname": "1.5x Dismember Damage/Heal"
   },
   "special_bonus_unique_pudge_4": {
-    "dname": "+{s:bonus_rot_slow}% Rot Slow"
+    "dname": "+10% Rot Slow"
   },
   "special_bonus_unique_pudge_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Meat Hook Cooldown"
+    "dname": "-4s Meat Hook Cooldown"
   },
   "special_bonus_unique_pudge_6": {
-    "dname": "+{s:bonus_AbilityChannelTime}s Dismember Duration"
+    "dname": "+0.75s Dismember Duration"
   },
   "special_bonus_unique_pudge_7": {
     "dname": "+{s:bonus_damage} Meat Hook Damage"
@@ -75854,10 +76141,10 @@
     "dname": "+{s:value} Living Armor Block Instances"
   },
   "special_bonus_unique_treant_2": {
-    "dname": "+{s:bonus_leech_damage} Leech Seed Bonus Damage"
+    "dname": "+80 Leech Seed Bonus Damage"
   },
   "special_bonus_unique_treant_3": {
-    "dname": "+{s:bonus_leech_heal}% Leech Seed Damage to Healing"
+    "dname": "+10% Leech Seed Damage to Healing"
   },
   "special_bonus_unique_treant_4": {
     "dname": "Nature's Guise Invisibility"
@@ -75869,13 +76156,13 @@
     "dname": "Global Living Armor"
   },
   "special_bonus_unique_treant_7": {
-    "dname": "{s:bonus_aoe_radius} AoE Living Armor"
+    "dname": "450 AoE Living Armor"
   },
   "special_bonus_unique_treant_8": {
-    "dname": "+{s:bonus_heal_per_second} Living Armor Heal Per Second"
+    "dname": "+3 Living Armor Heal Per Second"
   },
   "special_bonus_unique_treant_9": {
-    "dname": "+{s:bonus_damage_per_second} Nature's Grasp Damage"
+    "dname": "+25 Nature's Grasp Damage"
   },
   "special_bonus_unique_treant_10": {
     "dname": "Gains Tree Walking"
@@ -75884,25 +76171,25 @@
     "dname": "Overgrowth Undispellable"
   },
   "special_bonus_unique_treant_12": {
-    "dname": "+{s:bonus_movement_bonus}% Nature's Guise Movement Speed"
+    "dname": "+2.5% Nature's Guise Movement Speed"
   },
   "special_bonus_unique_treant_13": {
-    "dname": "+{s:bonus_damage_block_base} Living Armor Damage Block"
+    "dname": "+20 Living Armor Damage Block"
   },
   "special_bonus_unique_treant_14": {
-    "dname": "-{s:bonus_AbilityCooldown}s Leech Seed Cooldown"
+    "dname": "-3s Leech Seed Cooldown"
   },
   "special_bonus_unique_razor": {
-    "dname": "+{s:bonus_drain_rate} Static Link Damage Steal"
+    "dname": "+6 Static Link Damage Steal"
   },
   "special_bonus_unique_razor_2": {
-    "dname": "-{s:bonus_strike_interval}s Eye of the Storm Strike Interval"
+    "dname": "-0.1s Eye of the Storm Strike Interval"
   },
   "special_bonus_unique_razor_3": {
     "dname": "-{s:bonus_strike_internal_cd}s Storm Surge Strike Cooldown"
   },
   "special_bonus_unique_razor_4": {
-    "dname": "+{s:bonus_slow_duration}s Plasma Field Slow Duration"
+    "dname": "+0.75s Plasma Field Slow Duration"
   },
   "special_bonus_unique_razor_5": {
     "dname": "+{s:value}% Storm Surge Move Speed"
@@ -75914,82 +76201,82 @@
     "dname": "Static Link Steals Attack Speed"
   },
   "special_bonus_unique_razor_plasmafield_second_ring": {
-    "dname": "Creates A Second Plasma Field Delayed By {s:bonus_second_ring_delay}s"
+    "dname": "Creates A Second Plasma Field Delayed By 0.8s"
   },
   "special_bonus_unique_razor_storm_surge_damage_and_slow": {
-    "dname": "+{s:bonus_strike_move_slow_pct}% Storm Surge Slow and Damage"
+    "dname": "+35% Storm Surge Slow and Damage"
   },
   "special_bonus_unique_razor_plasmafield_max_slow": {
-    "dname": "+{s:bonus_slow_max}% Plasma Field Max Slow"
+    "dname": "+20% Plasma Field Max Slow"
   },
   "special_bonus_unique_visage_1": {
-    "dname": "+{s:bonus_armor_reduction_per_hit} Armor Corruption to Visage and Familiars"
+    "dname": "+1 Armor Corruption to Visage and Familiars"
   },
   "special_bonus_unique_visage_2": {
     "dname": "+{s:bonus_bonus_movement_speed} Visage and Familiars Movement Speed"
   },
   "special_bonus_unique_visage_3": {
-    "dname": "Soul Assumption Hits {s:bonus_target_count} Targets"
+    "dname": "Soul Assumption Hits =3 Targets"
   },
   "special_bonus_unique_visage_4": {
-    "dname": "+{s:bonus_soul_charge_damage} Soul Assumption Damage Per Charge"
+    "dname": "+30 Soul Assumption Damage Per Charge"
   },
   "special_bonus_unique_visage_5": {
     "dname": "Gravekeeper's Cloak  grants +{s:bonus_armor} Armor"
   },
   "special_bonus_unique_visage_6": {
-    "dname": "+{s:bonus_familiar_count} Familiar"
+    "dname": "+1 Familiar"
   },
   "special_bonus_unique_visage_7": {
-    "dname": "+{s:bonus_familiar_attack_damage} Visage and Familiars Base Damage"
+    "dname": "+6 Visage and Familiars Base Damage"
   },
   "special_bonus_unique_visage_8": {
-    "dname": "+{s:bonus_max_stacks} Lurker Max Stacks"
+    "dname": "+4 Lurker Max Stacks"
   },
   "special_bonus_unique_visage_grave_chill_duration": {
-    "dname": "+{s:bonus_chill_duration}s Grave Chill Duration"
+    "dname": "+2s Grave Chill Duration"
   },
   "special_bonus_unique_visage_cloak_recovery_time": {
-    "dname": "-{s:bonus_recovery_time}s Gravekeeper's Cloak Recovery Time"
+    "dname": "-2s Gravekeeper's Cloak Recovery Time"
   },
   "special_bonus_unique_visage_grave_chill_aoe": {
     "dname": "+{s:bonus_target_radius} AOE Grave Chill"
   },
   "special_bonus_unique_visage_familiar_armor_hp": {
-    "dname": "+{s:bonus_familiar_hp}% Familiar Health / Armor"
+    "dname": "+25% Familiar Health / Armor"
   },
   "special_bonus_unique_visage_soul_assumption_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Soul Assumption Cooldown"
+    "dname": "-1s Soul Assumption Cooldown"
   },
   "special_bonus_unique_earthshaker_5": {
     "dname": "+{s:bonus_aftershock_range} Aftershock Range"
   },
   "special_bonus_unique_lich_1": {
-    "dname": "Frost Shield Provides +{s:bonus_health_regen} HP Regen"
+    "dname": "Frost Shield Provides +50 HP Regen"
   },
   "special_bonus_unique_lich_2": {
-    "dname": "+{s:bonus_AbilityChannelTime}s Sinister Gaze Duration"
+    "dname": "+0.3s Sinister Gaze Duration"
   },
   "special_bonus_unique_lich_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Frost Blast Cooldown"
+    "dname": "-3.5s Frost Blast Cooldown"
   },
   "special_bonus_unique_lich_4": {
-    "dname": "{s:bonus_AbilityCharges} Frost Shield Charges"
+    "dname": "2 Frost Shield Charges"
   },
   "special_bonus_unique_lich_5": {
     "dname": "Chain Frost Unlimited Bounces"
   },
   "special_bonus_unique_lich_6": {
-    "dname": "+{s:bonus_radius} Frost Blast Radius and Area Damage"
+    "dname": "+125 Frost Blast Radius and Area Damage"
   },
   "special_bonus_unique_lich_7": {
     "dname": "Chain Frost on Death"
   },
   "special_bonus_unique_lich_8": {
-    "dname": "+{s:bonus_damage_reduction}% Frost Shield Damage Reduction"
+    "dname": "+10% Frost Shield Damage Reduction"
   },
   "special_bonus_unique_lich_jump_damage": {
-    "dname": "+{s:bonus_bonus_jump_damage} Chain Frost Incremental Damage"
+    "dname": "+100 Chain Frost Incremental Damage"
   },
   "special_bonus_unique_rubick": {
     "dname": "+{s:bonus_max_land_distance} Telekinesis Land Distance"
@@ -75998,73 +76285,73 @@
     "dname": "+{s:bonus_bonus_damage_pct_tooltip}% Might And Magus Damage/Resistance"
   },
   "special_bonus_unique_rubick_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Fade Bolt Cooldown"
+    "dname": "-4s Fade Bolt Cooldown"
   },
   "special_bonus_unique_rubick_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Telekinesis Cooldown"
+    "dname": "-2s Telekinesis Cooldown"
   },
   "special_bonus_unique_rubick_5": {
-    "dname": "+{s:bonus_spell_amp_percent}% Spell Amp For Stolen Spells"
+    "dname": "+40% Spell Amp For Stolen Spells"
   },
   "special_bonus_unique_rubick_6": {
-    "dname": "-{s:bonus_stolen_mana_reduction}% Stolen Spells Mana Cost"
+    "dname": "-40% Stolen Spells Mana Cost"
   },
   "special_bonus_unique_rubick_7": {
     "dname": "+{s:bonus_attack_damage_reduction}% Fade Bolt Damage Reduction"
   },
   "special_bonus_unique_rubick_8": {
-    "dname": "Telekinesis Landing Deals {s:bonus_landing_damage} Damage"
+    "dname": "Telekinesis Landing Deals 300 Damage"
   },
   "special_bonus_unique_sven": {
-    "dname": "+{s:bonus_bonus_damage_pct}% Storm Bolt Damage Amplification"
+    "dname": "+20% Storm Bolt Damage Amplification"
   },
   "special_bonus_unique_sven_2": {
-    "dname": "+{s:bonus_gods_strength_damage}% God's Strength Damage"
+    "dname": "+50% God's Strength Damage"
   },
   "special_bonus_unique_sven_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s God's Strength Cooldown"
+    "dname": "-12s God's Strength Cooldown"
   },
   "special_bonus_unique_sven_4": {
-    "dname": "+{s:bonus_bolt_stun_duration}s Storm Hammer Stun Duration"
+    "dname": "+1s Storm Hammer Stun Duration"
   },
   "special_bonus_unique_sven_5": {
-    "dname": "+{s:bonus_duration}s Warcry Duration"
+    "dname": "+5s Warcry Duration"
   },
   "special_bonus_unique_sven_6": {
     "dname": "+{s:bonus_movespeed}% Warcry Movement Speed"
   },
   "special_bonus_unique_sven_7": {
-    "dname": "+{s:bonus_bonus_armor} Warcry Armor"
+    "dname": "+8 Warcry Armor"
   },
   "special_bonus_unique_sven_8": {
-    "dname": "+{s:bonus_great_cleave_damage}% Great Cleave Damage"
+    "dname": "+25% Great Cleave Damage"
   },
   "special_bonus_unique_sven_stormhammer_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}% Storm Hammer Cooldown and Mana Cost"
+    "dname": "-25% Storm Hammer Cooldown and Mana Cost"
   },
   "special_bonus_unique_sven_gods_strength_slow_resist": {
-    "dname": "+{s:bonus_bonus_slow_resistance}% God's Strength Slow Resistance"
+    "dname": "+20% God's Strength Slow Resistance"
   },
   "special_bonus_unique_dark_seer": {
-    "dname": "+{s:bonus_damage_per_second} Ion Shell Damage"
+    "dname": "+50 Ion Shell Damage"
   },
   "special_bonus_unique_dark_seer_2": {
-    "dname": "+{s:bonus_radius} Vacuum AoE"
+    "dname": "+75 Vacuum AoE"
   },
   "special_bonus_unique_dark_seer_3": {
-    "dname": "{s:bonus_aoe_radius} AoE Surge"
+    "dname": "350 AoE Surge"
   },
   "special_bonus_unique_dark_seer_4": {
     "dname": "Parallel Wall"
   },
   "special_bonus_unique_dark_seer_5": {
-    "dname": "+{s:bonus_radius} Ion Shell Radius"
+    "dname": "+65 Ion Shell Radius"
   },
   "special_bonus_unique_dark_seer_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Surge Cooldown"
+    "dname": "-1.5s Surge Cooldown"
   },
   "special_bonus_unique_dark_seer_7": {
-    "dname": "+{s:bonus_tooltip_outgoing}% Wall of Replica Illusion Damage"
+    "dname": "+15% Wall of Replica Illusion Damage"
   },
   "special_bonus_unique_dark_seer_8": {
     "dname": "-{s:value}s Vacuum Cooldown"
@@ -76082,61 +76369,61 @@
     "dname": "+{s:value}s Wall of Replica Slow"
   },
   "special_bonus_unique_dark_seer_13": {
-    "dname": "-{s:bonus_cooldown_reduction}s Wall of Replica Cooldown"
+    "dname": "-40s Wall of Replica Cooldown"
   },
   "special_bonus_unique_dark_seer_14": {
-    "dname": "{s:bonus_AbilityCharges} Ion Shell Charges "
+    "dname": "2 Ion Shell Charges "
   },
   "special_bonus_unique_dark_seer_15": {
     "dname": "+{s:bonus_duration}s Ion Shell Duration"
   },
   "special_bonus_unique_shadow_shaman_1": {
-    "dname": "+{s:bonus_hits_to_destroy_tooltip}% Serpent Wards Max HP"
+    "dname": "+50% Serpent Wards Max HP"
   },
   "special_bonus_unique_shadow_shaman_2": {
-    "dname": "+{s:bonus_channel_time}s Shackles Duration"
+    "dname": "+1.5s Shackles Duration"
   },
   "special_bonus_unique_shadow_shaman_3": {
-    "dname": "+{s:bonus_damage} Ether Shock Damage"
+    "dname": "+250 Ether Shock Damage"
   },
   "special_bonus_unique_shadow_shaman_4": {
-    "dname": "+{s:bonus_bonus_attack_targets} Ward Attack Targets"
+    "dname": "+1 Ward Attack Targets"
   },
   "special_bonus_unique_shadow_shaman_5": {
     "dname": "-{s:value}s Hex Cooldown"
   },
   "special_bonus_unique_shadow_shaman_6": {
-    "dname": "+{s:bonus_total_damage} Shackles Total Damage"
+    "dname": "+170 Shackles Total Damage"
   },
   "special_bonus_unique_shadow_shaman_7": {
     "dname": "Hex Breaks"
   },
   "special_bonus_unique_shadow_shaman_8": {
-    "dname": "+{s:bonus_bonus_attack_range} Serpent Wards Attack Range"
+    "dname": "+160 Serpent Wards Attack Range"
   },
   "special_bonus_unique_shadow_shaman_hex_damage_amp": {
-    "dname": "+{s:bonus_damage_amp} Hex Damage Amplification"
+    "dname": "+0 Hex Damage Amplification"
   },
   "special_bonus_unique_warlock_1": {
-    "dname": "{s:bonus_bonus_damage_resist}% Damage Resistance for Chaotic Offering Golems"
+    "dname": "25% Damage Resistance for Chaotic Offering Golems"
   },
   "special_bonus_unique_warlock_2": {
-    "dname": "+{s:bonus_bonus_armor} Chaotic Offering Golems Armor"
+    "dname": "+20 Chaotic Offering Golems Armor"
   },
   "special_bonus_unique_warlock_3": {
-    "dname": "+{s:bonus_base_damage} Upheaval Damage"
+    "dname": "+=45 Upheaval Damage"
   },
   "special_bonus_unique_warlock_4": {
     "dname": "Summons a Golem on death"
   },
   "special_bonus_unique_warlock_5": {
-    "dname": "+{s:bonus_damage_share_percentage}% Fatal Bonds Damage"
+    "dname": "+4% Fatal Bonds Damage"
   },
   "special_bonus_unique_warlock_6": {
     "dname": "{s:value} Shadow Word AoE"
   },
   "special_bonus_unique_warlock_7": {
-    "dname": "+{s:bonus_spell_aoe} Shadow Word AoE"
+    "dname": "+150 Shadow Word AoE"
   },
   "special_bonus_unique_warlock_8": {
     "dname": "+{s:bonus_duration}s Shadow Word Duration"
@@ -76145,31 +76432,31 @@
     "dname": "+{s:value} Fatal Bond Targets"
   },
   "special_bonus_unique_warlock_10": {
-    "dname": "+{s:bonus_aspd_per_second} Upheaval Attack Speed per second on Allies"
+    "dname": "+8 Upheaval Attack Speed per second on Allies"
   },
   "special_bonus_unique_warlock_upheaval_aoe": {
-    "dname": "+{s:bonus_aoe} Upheaval Radius"
+    "dname": "+50 Upheaval Radius"
   },
   "special_bonus_unique_warlock_shadow_word_duration": {
     "dname": "+{s:bonus_duration}s Shadow Word Duration"
   },
   "special_bonus_unique_warlock_fatal_bonds_count": {
-    "dname": "+{s:bonus_count} Fatal Bonds Targets"
+    "dname": "+5 Fatal Bonds Targets"
   },
   "special_bonus_unique_vengeful_spirit_1": {
-    "dname": "+{s:bonus_magic_missile_stun}s Magic Missile Stun Duration"
+    "dname": "+0.3s Magic Missile Stun Duration"
   },
   "special_bonus_unique_vengeful_spirit_2": {
-    "dname": "+{s:bonus_bonus_base_damage}% Vengeance Aura Base Damage Bonus"
+    "dname": "+16% Vengeance Aura Base Damage Bonus"
   },
   "special_bonus_unique_vengeful_spirit_3": {
     "dname": "Magic Missile Damage Becomes Pure And Pierces Debuff Immunity"
   },
   "special_bonus_unique_vengeful_spirit_4": {
-    "dname": "-{s:bonus_armor_reduction} Wave of Terror Armor"
+    "dname": "-3 Wave of Terror Armor"
   },
   "special_bonus_unique_vengeful_spirit_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Magic Missile Cooldown"
+    "dname": "-2s Magic Missile Cooldown"
   },
   "special_bonus_unique_vengeful_spirit_6": {
     "dname": "-{s:value}s Wave of Terror Cooldown"
@@ -76181,31 +76468,31 @@
     "dname": "+{s:value} Vengeance Aura Attack Range"
   },
   "special_bonus_unique_vengeful_spirit_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Nether Swap Cooldown"
+    "dname": "-18s Nether Swap Cooldown"
   },
   "special_bonus_unique_vengeful_spirit_swap_damage": {
-    "dname": "+{s:bonus_damage} Nether Swap Enemy Damage"
+    "dname": "+150 Nether Swap Enemy Damage"
   },
   "special_bonus_unique_vengeful_spirit_missile_castrange": {
-    "dname": "+{s:bonus_AbilityCastRange} Magic Missile Cast Range"
+    "dname": "+100 Magic Missile Cast Range"
   },
   "special_bonus_unique_vengeful_spirit_swap_damage_reduction": {
     "dname": "+{s:bonus_damage_reduction}% Nether Swap Damage Reduction"
   },
   "special_bonus_unique_vengeful_spirit_wave_of_terror_steal": {
-    "dname": "Wave Of Terror Steals {s:bonus_steal_pct}% Of Reduced Damage And Armor"
+    "dname": "Wave Of Terror Steals 25% Of Reduced Damage And Armor"
   },
   "special_bonus_unique_venomancer": {
-    "dname": "{s:bonus_ward_hp_tooltip}x Plague Ward HP/Damage"
+    "dname": "2.5x Plague Ward HP/Damage"
   },
   "special_bonus_unique_venomancer_2": {
-    "dname": "+{s:bonus_movement_speed}% Poison Sting Slow"
+    "dname": "+10% Poison Sting Slow"
   },
   "special_bonus_unique_venomancer_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Venomous Gale CD"
+    "dname": "-5s Venomous Gale CD"
   },
   "special_bonus_unique_venomancer_4": {
-    "dname": "+{s:bonus_tick_damage}% Snakebite Damage"
+    "dname": "+100 Snakebite Initial Damage"
   },
   "special_bonus_unique_venomancer_5": {
     "dname": "Snakebite Undispellable"
@@ -76217,16 +76504,16 @@
     "dname": "+{s:value}s Plague Ward Duration"
   },
   "special_bonus_unique_venomancer_8": {
-    "dname": "-{s:bonus_AbilityCooldown}s Plague Ward Cooldown"
+    "dname": "-2s Plague Ward Cooldown"
   },
   "special_bonus_unique_venomancer_plague_spread": {
-    "dname": "+{s:bonus_debuff_radius} Noxious Plague Spread Radius"
+    "dname": "+75 Noxious Plague Spread Radius"
   },
   "special_bonus_unique_venomancer_poisonsting_regen_reduction": {
-    "dname": "{s:bonus_hp_regen_reduction}% Poison Sting Health Regen Reduction"
+    "dname": "15% Poison Sting Health Regen Reduction"
   },
   "special_bonus_unique_morphling_1": {
-    "dname": "+{s:bonus_AbilityCastRange} Waveform Range"
+    "dname": "+250 Waveform Range"
   },
   "special_bonus_unique_morphling_2": {
     "dname": "-{s:value} Morph Cooldown"
@@ -76244,10 +76531,10 @@
     "dname": "{s:bonus_AbilityCharges} Waveform Charges"
   },
   "special_bonus_unique_morphling_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Adaptive Strike Cooldown"
+    "dname": "-3s Adaptive Strike Cooldown"
   },
   "special_bonus_unique_morphling_8": {
-    "dname": "+{s:bonus_duration}s Morph Duration"
+    "dname": "+12s Morph Duration"
   },
   "special_bonus_unique_morphling_9": {
     "dname": "-{s:value} Adaptive Strike Armor Reduction"
@@ -76256,25 +76543,25 @@
     "dname": "+{s:bonus_stun_max}s Adaptive Strike Stun Duration"
   },
   "special_bonus_unique_morphling_waveform_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}% Waveform Cooldown"
+    "dname": "-40% Waveform Cooldown"
   },
   "special_bonus_unique_leshrac_1": {
-    "dname": "+{s:bonus_num_explosions} Diabolic Edict Explosions"
+    "dname": "+20 Diabolic Edict Explosions"
   },
   "special_bonus_unique_leshrac_2": {
     "dname": "{s:bonus_mana_pct_per_hit}% of Damage Dealt by Attacks Restored As Mana"
   },
   "special_bonus_unique_leshrac_3": {
-    "dname": "+{s:bonus_damage} Pulse Nova Damage"
+    "dname": "+30 Pulse Nova Damage"
   },
   "special_bonus_unique_leshrac_4": {
-    "dname": "+{s:bonus_damage_resistance}% Damage Reduction during Pulse Nova"
+    "dname": "+10% Damage Reduction during Pulse Nova"
   },
   "special_bonus_unique_leshrac_5": {
     "dname": "+{s:value} Split Earth Radius"
   },
   "special_bonus_unique_leshrac_6": {
-    "dname": "+{s:bonus_damage} Lightning Storm Damage"
+    "dname": "+80 Lightning Storm Damage"
   },
   "special_bonus_unique_leshrac_7": {
     "dname": "Diabolic Edict Hits An Additional Target"
@@ -76283,25 +76570,25 @@
     "dname": "Pulse Nova triggers Lightning Storm"
   },
   "special_bonus_unique_jakiro": {
-    "dname": "+{s:bonus_stun_duration}s Ice Path Stun Duration"
+    "dname": "+0.4s Ice Path Stun Duration"
   },
   "special_bonus_unique_jakiro_2": {
-    "dname": "+{s:bonus_AbilityCastRange}% Dual Breath Damage and Range"
+    "dname": "+100% Dual Breath Damage and Range"
   },
   "special_bonus_unique_jakiro_3": {
-    "dname": "+{s:bonus_pct_health_damage}% Liquid Frost and Fire Max Health Damage"
+    "dname": "+3.5% Liquid Frost and Fire Max Health Damage"
   },
   "special_bonus_unique_jakiro_4": {
-    "dname": "+{s:bonus_slow_attack_speed_pct} Liquid Fire Attack Speed Slow"
+    "dname": "+30 Liquid Fire Attack Speed Slow"
   },
   "special_bonus_unique_jakiro_5": {
     "dname": "+{s:value} Dual Breath Range"
   },
   "special_bonus_unique_jakiro_6": {
-    "dname": "+{s:bonus_damage} Ice Path Damage"
+    "dname": "+100 Ice Path Damage"
   },
   "special_bonus_unique_jakiro_7": {
-    "dname": "+{s:bonus_damage} Macropyre Damage"
+    "dname": "+25 Macropyre Damage"
   },
   "special_bonus_unique_jakiro_8": {
     "dname": "+{s:bonus_damage} Liquid Fire Damage"
@@ -76310,7 +76597,7 @@
     "dname": "-{s:bonus_slow_movement_speed_pct}%/{s:bonus_slow_attack_speed_pct} Dual Breath Movement/Attack Speed Slow"
   },
   "special_bonus_unique_jakiro_dualbreath_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Dual Breath Cooldown"
+    "dname": "-3.5s Dual Breath Cooldown"
   },
   "special_bonus_unique_enigma_7": {
     "dname": "+{s:bonus_eidelon_max_health} Eidolon Health"
@@ -76322,16 +76609,16 @@
     "dname": "+{s:value} Enfeeble Attack Speed Reduction"
   },
   "special_bonus_unique_bane_2": {
-    "dname": "+{s:bonus_brain_sap_damage} Brain Sap Damage/Heal"
+    "dname": "+275 Brain Sap Damage/Heal"
   },
   "special_bonus_unique_bane_3": {
-    "dname": "+{s:bonus_AbilityChannelTime}s Fiend's Grip Duration"
+    "dname": "+3s Fiend's Grip Duration"
   },
   "special_bonus_unique_bane_4": {
     "dname": "Enfeeble Steals Attack Speed"
   },
   "special_bonus_unique_bane_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Nightmare Cooldown"
+    "dname": "-3s Nightmare Cooldown"
   },
   "special_bonus_unique_bane_6": {
     "dname": "-{s:value}% Enfeeble Regen Reduction"
@@ -76340,37 +76627,37 @@
     "dname": "Brain Sap Pure and Pierces Immunity"
   },
   "special_bonus_unique_bane_8": {
-    "dname": "+{s:bonus_AbilityCastRange} Brain Sap Cast Range"
+    "dname": "+125 Brain Sap Cast Range"
   },
   "special_bonus_unique_bane_9": {
-    "dname": "+{s:bonus_fiend_grip_mana_drain}% Fiend's Grip Max Mana Drain"
+    "dname": "+5% Fiend's Grip Max Mana Drain"
   },
   "special_bonus_unique_bane_10": {
-    "dname": "+{s:bonus_enfeeble_tick_damage} Enfeeble Damage Per Second"
+    "dname": "+13 Enfeeble Damage Per Second"
   },
   "special_bonus_unique_bane_11": {
-    "dname": "+{s:bonus_cast_reduction}% Enfeeble Cast Range Reduction"
+    "dname": "+20% Enfeeble Cast Range Reduction"
   },
   "special_bonus_unique_nevermore_1": {
-    "dname": "+{s:bonus_necromastery_max_souls} Necromastery Max Souls"
+    "dname": "+5 Necromastery Max Souls"
   },
   "special_bonus_unique_nevermore_2": {
     "dname": "+{s:bonus_shadowraze_damage} Shadowraze Damage"
   },
   "special_bonus_unique_nevermore_3": {
-    "dname": "+{s:bonus_presence_armor_reduction} Presence Armor Reduction"
+    "dname": "+2 Presence Armor Reduction"
   },
   "special_bonus_unique_nevermore_4": {
-    "dname": "+{s:bonus_bonus_attack_speed} Feast of Souls Attack Speed"
+    "dname": "+30 Feast of Souls Attack Speed"
   },
   "special_bonus_unique_nevermore_5": {
     "dname": "{s:value} Presence Aura Armor"
   },
   "special_bonus_unique_nevermore_6": {
-    "dname": "+{s:bonus_requiem_slow_duration}s Requiem Fear per line"
+    "dname": "+0.2s Requiem Fear per line"
   },
   "special_bonus_unique_nevermore_7": {
-    "dname": "+{s:bonus_stack_bonus_damage} Shadowraze Stack Damage"
+    "dname": "+30 Shadowraze Stack Damage"
   },
   "special_bonus_unique_nevermore_shadowraze_cooldown": {
     "dname": "-{s:bonus_AbilityCooldown}s Shadowraze Cooldown"
@@ -76379,19 +76666,19 @@
     "dname": "Shadowraze Applies Attack Damage"
   },
   "special_bonus_unique_nevermore_frenzy_castspeed": {
-    "dname": "Feast of Souls Grants +{s:bonus_cast_speed_pct}% Cast Speed"
+    "dname": "Feast of Souls Grants +30% Cast Speed"
   },
   "special_bonus_unique_nevermore_frenzy_max_collection_count": {
-    "dname": "+{s:bonus_soul_collection_per_hero} Feast of Souls Souls Collected Per Hero"
+    "dname": "+2 Feast of Souls Souls Collected Per Hero"
   },
   "special_bonus_unique_templar_assassin": {
-    "dname": "+{s:bonus_instances} Refraction Instances"
+    "dname": "+4 Refraction Instances"
   },
   "special_bonus_unique_templar_assassin_2": {
     "dname": "+{s:bonus_bonus_armor} Meld Armor Reduction"
   },
   "special_bonus_unique_templar_assassin_3": {
-    "dname": "+{s:bonus_movement_speed_min}% Psionic Trap Slow"
+    "dname": "+15% Psionic Trap Slow"
   },
   "special_bonus_unique_templar_assassin_4": {
     "dname": "Refraction Dispels"
@@ -76400,13 +76687,13 @@
     "dname": "Psi Blades Split Paralyzes"
   },
   "special_bonus_unique_templar_assassin_6": {
-    "dname": "+{s:bonus_max_traps} Psionic Traps"
+    "dname": "+3 Psionic Traps"
   },
   "special_bonus_unique_templar_assassin_7": {
-    "dname": "{s:bonus_bash_duration}s Meld Hit Bash"
+    "dname": "=0.8s Meld Hit Bash"
   },
   "special_bonus_unique_templar_assassin_8": {
-    "dname": "+{s:bonus_bonus_armor} Meld Armor Reduction"
+    "dname": "+4 Meld Armor Reduction"
   },
   "special_bonus_unique_templar_assassin_refraction_damage": {
     "dname": "+{s:bonus_bonus_damage} Refraction Damage"
@@ -76415,37 +76702,37 @@
     "dname": "Refraction Can Be Cast While Disabled"
   },
   "special_bonus_unique_templar_assassin_meld_duration": {
-    "dname": "+{s:bonus_debuff_duration}s Meld Debuff Duration"
+    "dname": "+1.5s Meld Debuff Duration"
   },
   "special_bonus_unique_templar_assassin_meld_attack_range_bonus": {
-    "dname": "+{s:bonus_attack_range_bonus} Meld Attack Range"
+    "dname": "+225 Meld Attack Range"
   },
   "special_bonus_unique_crystal_maiden_1": {
-    "dname": "+{s:bonus_duration}s Frostbite Duration"
+    "dname": "+1.0s Frostbite Duration"
   },
   "special_bonus_unique_crystal_maiden_2": {
-    "dname": "+{s:bonus_nova_damage} Crystal Nova Damage"
+    "dname": "+300 Crystal Nova Damage"
   },
   "special_bonus_unique_crystal_maiden_3": {
-    "dname": "+{s:bonus_damage} Freezing Field Damage"
+    "dname": "+50 Freezing Field Damage"
   },
   "special_bonus_unique_crystal_maiden_4": {
     "dname": "+{s:bonus_base_mana_regen} Arcane Aura Base Mana Regeneration"
   },
   "special_bonus_unique_crystal_maiden_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Crystal Nova Cooldown"
+    "dname": "-4.5s Crystal Nova Cooldown"
   },
   "special_bonus_unique_crystal_maiden_6": {
     "dname": "+{s:bonus_radius} Crystal Nova AoE"
   },
   "special_bonus_unique_crystal_maiden_frostbite_castrange": {
-    "dname": "+{s:bonus_AbilityCastRange} Frostbite Cast Range"
+    "dname": "+100 Frostbite Cast Range"
   },
   "special_bonus_unique_crystal_maiden_glacial_guard_mana_multiplier": {
-    "dname": "+{s:bonus_mana_multiplier}% Glacial Guard Mana Spent To Barrier"
+    "dname": "+20% Glacial Guard Mana Spent To Barrier"
   },
   "special_bonus_unique_doom_1": {
-    "dname": "+{s:bonus_burn_damage_pct}% Infernal Blade Max HP As Damage"
+    "dname": "+1.5% Infernal Blade Max HP As Damage"
   },
   "special_bonus_unique_doom_2": {
     "dname": "Devour Can Target Ancients"
@@ -76454,13 +76741,13 @@
     "dname": "Devour grants {s:bonus_magic_resist}% Magic Resistance"
   },
   "special_bonus_unique_doom_4": {
-    "dname": "+{s:bonus_ministun_duration}s Infernal Blade Stun Duration"
+    "dname": "+0.2s Infernal Blade Stun Duration"
   },
   "special_bonus_unique_doom_5": {
     "dname": "+{s:bonus_damage} Doom DPS"
   },
   "special_bonus_unique_doom_6": {
-    "dname": "+{s:bonus_bonus_movement_speed_pct}% Scorched Earth Movement Speed"
+    "dname": "+7% Scorched Earth Movement Speed"
   },
   "special_bonus_unique_doom_7": {
     "dname": "+{s:bonus_duration}s Doom Duration"
@@ -76469,7 +76756,7 @@
     "dname": "Permanent Scorched Earth"
   },
   "special_bonus_unique_doom_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Doom Cooldown"
+    "dname": "-10s Doom Cooldown"
   },
   "special_bonus_unique_doom_10": {
     "dname": "Doom applies Mute"
@@ -76478,10 +76765,10 @@
     "dname": "Permanent Scorched Earth"
   },
   "special_bonus_unique_brewmaster": {
-    "dname": "+{s:bonus_bonus_brewling_hp} Brewlings Health"
+    "dname": "+600 Brewlings Health"
   },
   "special_bonus_unique_brewmaster_2": {
-    "dname": "+{s:bonus_bonus_damage} Brewlings Base Damage"
+    "dname": "+13 Brewlings Base Damage"
   },
   "special_bonus_unique_brewmaster_3": {
     "dname": "+{s:value}s Thunder Clap Slow"
@@ -76490,7 +76777,7 @@
     "dname": "Cinder Brew applies Fear when ignited"
   },
   "special_bonus_unique_brewmaster_5": {
-    "dname": "+{s:bonus_total_ignite_damage}% Cinder Brew Damage/Duration"
+    "dname": "+40% Cinder Brew Damage/Duration"
   },
   "special_bonus_unique_brewmaster_6": {
     "dname": "Brewlings Gain Drunken Brawler Passive"
@@ -76499,16 +76786,16 @@
     "dname": "+{s:bonus_duration}s Thunder Clap Duration"
   },
   "special_bonus_unique_brewmaster_primal_split_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Primal Split Cooldown"
+    "dname": "-12s Primal Split Cooldown"
   },
   "special_bonus_unique_brewmaster_8": {
     "dname": "+{s:bonus_active_multiplier}% Brewed Up Multiplier for Drunken Brawler"
   },
   "special_bonus_unique_bristleback": {
-    "dname": "-{s:bonus_quill_release_threshold} Bristleback Damage Threshold"
+    "dname": "-30 Bristleback Damage Threshold"
   },
   "special_bonus_unique_bristleback_2": {
-    "dname": "+{s:bonus_quill_stack_damage} Quill Stack Damage"
+    "dname": "+20 Quill Stack Damage"
   },
   "special_bonus_unique_bristleback_3": {
     "dname": "+{s:bonus_damage_per_stack} Warpath Damage Per Stack"
@@ -76517,10 +76804,10 @@
     "dname": "-{s:bonus_armor_per_stack} Goo Armor Per Stack"
   },
   "special_bonus_unique_bristleback_5": {
-    "dname": "+{s:bonus_AbilityCastRange} Goo Cast Range"
+    "dname": "+250 Goo Cast Range"
   },
   "special_bonus_unique_bristleback_6": {
-    "dname": "+{s:bonus_back_damage_reduction}%/{s:bonus_side_damage_reduction}% Bristleback Back/Side Damage Reduction"
+    "dname": "+8%/4% Bristleback Back/Side Damage Reduction"
   },
   "special_bonus_unique_furion_8_facet_furion_soothing_saplings": {
     "dname": "+{s:bonus_sprout_heal_per_second}% Sprout Heal Per Second"
@@ -76541,34 +76828,34 @@
     "dname": "Enchant Affects Ancients"
   },
   "special_bonus_unique_enchantress_2": {
-    "dname": "+{s:bonus_wisp_count} Nature's Attendants Wisps"
+    "dname": "+9 Nature's Attendants Wisps"
   },
   "special_bonus_unique_enchantress_3": {
-    "dname": "+{s:bonus_slow_attack_speed} Untouchable Attack Slow"
+    "dname": "+80 Untouchable Attack Slow"
   },
   "special_bonus_unique_enchantress_4": {
-    "dname": "+{s:bonus_distance_damage_pct}% Impetus Damage"
+    "dname": "+6.5% Impetus Damage"
   },
   "special_bonus_unique_enchantress_5": {
-    "dname": "+{s:bonus_heal} Nature's Attendants Heal"
+    "dname": "+8 Nature's Attendants Heal"
   },
   "special_bonus_unique_enchantress_6": {
-    "dname": "+{s:bonus_movespeed} Movespeed during Nature's Attendants"
+    "dname": "+30 Movespeed during Nature's Attendants"
   },
   "special_bonus_unique_enchantress_enchant_health_damage": {
-    "dname": "+{s:bonus_bonus_health} Health / +{s:bonus_bonus_damage} Damage  for Enchantress and her units"
+    "dname": "+150 Health / +25 Damage  for Enchantress and her units"
   },
   "special_bonus_unique_enchantress_enchant_attackspeed": {
-    "dname": "+{s:bonus_bonus_attackspeed} Attack Speed for Enchantress and her units"
+    "dname": "+30 Attack Speed for Enchantress and her units"
   },
   "special_bonus_unique_enchantress_enchant_armor": {
-    "dname": "+{s:bonus_bonus_armor} Armor for Enchantress and her units"
+    "dname": "+5 Armor for Enchantress and her units"
   },
   "special_bonus_unique_wraith_king_1": {
     "dname": "No Reincarnation Manacost"
   },
   "special_bonus_unique_wraith_king_2": {
-    "dname": "+{s:bonus_vampiric_aura}% Vampiric Spirit Lifesteal"
+    "dname": "+8% Vampiric Spirit Lifesteal"
   },
   "special_bonus_unique_wraith_king_3": {
     "dname": "+{s:bonus_blast_dot_damage}% Wraithfire Blast Impact Damage/DPS"
@@ -76592,19 +76879,19 @@
     "dname": "-{s:value}s Wraithfire Blast Cooldown"
   },
   "special_bonus_unique_wraith_king_10": {
-    "dname": "-{s:bonus_AbilityCooldown}s Mortal Strike Cooldown"
+    "dname": "-2s Mortal Strike Cooldown"
   },
   "special_bonus_unique_wraith_king_11": {
-    "dname": "+{s:bonus_blast_stun_duration}s Wraithfire Blast Stun Duration"
+    "dname": "+0.75s Wraithfire Blast Stun Duration"
   },
   "special_bonus_unique_wraith_king_facet_1": {
-    "dname": "+{s:bonus_blast_dot_duration}s Wraithfire Blast Slow Duration"
+    "dname": "+2s Wraithfire Blast Slow Duration"
   },
   "special_bonus_unique_wraith_king_facet_2": {
     "dname": "+{s:bonus_talent_skeleton_damage} Bone Guard Skeleton Damage"
   },
   "special_bonus_unique_wraith_king_facet_3": {
-    "dname": "+{s:bonus_min_skeleton_spawn} Bone Guard Skeletons Spawned"
+    "dname": "+5 Bone Guard Skeletons Spawned"
   },
   "special_bonus_unique_wraith_king_vampiric_skeleton_duration": {
     "dname": "+{s:bonus_skeleton_duration}% Summon Skeleton Duration/-{s:bonus_AbilityCooldown}% Cooldown"
@@ -76616,13 +76903,13 @@
     "dname": "-{s:bonus_AbilityCooldown} Ghostship Cooldown"
   },
   "special_bonus_unique_kunkka_2": {
-    "dname": "+{s:bonus_damage_bonus} Tidebringer Damage"
+    "dname": "+75 Tidebringer Damage"
   },
   "special_bonus_unique_kunkka_3": {
     "dname": "-{s:bonus_AbilityCooldown}s Admiral's Rum Cooldown"
   },
   "special_bonus_unique_kunkka_4": {
-    "dname": "+{s:bonus_cleave_damage}% Tidebringer Cleave Damage"
+    "dname": "+80% Tidebringer Cleave Damage"
   },
   "special_bonus_unique_kunkka_5": {
     "dname": "-{s:bonus_AbilityCooldown}s Tidebringer Cooldown"
@@ -76631,43 +76918,43 @@
     "dname": "+{s:bonus_ally_ms}% X Marks the Spot Move Speed"
   },
   "special_bonus_unique_kunkka_7": {
-    "dname": "+{s:bonus_stun_duration}% Torrent Damage/Knock Up Duration"
+    "dname": "+25% Torrent Damage/Knock Up Duration"
   },
   "special_bonus_unique_kunkka_tidebringer_slow": {
-    "dname": "Tidebringer applies {s:bonus_movespeed_slow}% slow for {s:bonus_movespeed_slow_duration}s"
+    "dname": "Tidebringer applies 60% slow for 1s"
   },
   "special_bonus_unique_kunkka_tidebringer_cooldown_per_hit": {
     "dname": "-{s:bonus_cooldown_reduction_per_hero_hit}s Tidebringer cooldown per enemy Hero hit"
   },
   "special_bonus_unique_kunkka_torrent_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Torrent Cooldown"
+    "dname": "-4s Torrent Cooldown"
   },
   "special_bonus_unique_kunkka_rum": {
-    "dname": "+{s:bonus_ghostship_absorb}% Admiral's Rum Damage Delayed"
+    "dname": "+8% Admiral's Rum Damage Delayed"
   },
   "special_bonus_unique_kunkka_admirals_rum_delay": {
     "dname": "+{s:bonus_delay_time}s Admiral's Rum Delay Time"
   },
   "special_bonus_unique_kunkka_rum_duration": {
-    "dname": "+{s:bonus_buff_duration}s Admiral's Rum Buff Duration"
+    "dname": "+1s Admiral's Rum Buff Duration"
   },
   "special_bonus_unique_kunkka_tidebringer_charges": {
-    "dname": "{s:bonus_AbilityCharges} Tidebringer Charges"
+    "dname": "2 Tidebringer Charges"
   },
   "special_bonus_unique_kunkka_tidebringer_armor_pierce": {
-    "dname": "Tidebringer Ignores {s:bonus_pierces_armor}% Armor"
+    "dname": "Tidebringer Ignores 25% Armor"
   },
   "special_bonus_unique_dragon_knight": {
-    "dname": "+{s:bonus_health_regen} Dragon Blood HP Regen/Armor"
+    "dname": "+12 Dragon Blood HP Regen/Armor"
   },
   "special_bonus_unique_dragon_knight_2": {
-    "dname": "+{s:bonus_stun_duration}s Dragon Tail Stun"
+    "dname": "+0.4s Dragon Tail Stun"
   },
   "special_bonus_unique_dragon_knight_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Breathe Fire Cooldown"
+    "dname": "-2s Breathe Fire Cooldown"
   },
   "special_bonus_unique_dragon_knight_wyrms_wrath_damage": {
-    "dname": "+{s:bonus_magic_damage}% Wyrm's Wrath Bonuses"
+    "dname": "+50% Wyrm's Wrath Bonuses"
   },
   "special_bonus_unique_dragon_knight_4": {
     "dname": "Wyrm's Wrath Aura"
@@ -76679,13 +76966,13 @@
     "dname": "+{s:value}% Splash Attack Damage"
   },
   "special_bonus_unique_dragon_knight_7": {
-    "dname": "+{s:bonus_bonus_attack_range} Elder Dragon Form Attack Range"
+    "dname": "+150 Elder Dragon Form Attack Range"
   },
   "special_bonus_unique_dragon_knight_8": {
     "dname": "+{s:bonus_outgoing_damage_per_stack}% Wyrm's Wrath Damage Per Stack"
   },
   "special_bonus_unique_dragon_knight_9": {
-    "dname": "+{s:bonus_damage} Breathe Fire Damage"
+    "dname": "+220 Breathe Fire Damage"
   },
   "special_bonus_unique_invoker_1": {
     "dname": "{s:bonus_spirit_count} Forged Spirits Summoned"
@@ -76694,13 +76981,13 @@
     "dname": "Radial Deafening Blast"
   },
   "special_bonus_unique_invoker_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Tornado Cooldown"
+    "dname": "-5s Tornado Cooldown"
   },
   "special_bonus_unique_invoker_4": {
     "dname": "Cataclysm"
   },
   "special_bonus_unique_invoker_5": {
-    "dname": "+{s:bonus_bonus_attack_speed} Alacrity Damage/Speed"
+    "dname": "+25 Alacrity Damage/Speed"
   },
   "special_bonus_unique_invoker_6": {
     "dname": "+{s:bonus_main_damage}% Chaos Meteor Damage"
@@ -76712,13 +76999,13 @@
     "dname": "+{s:bonus_lift_duration}s Tornado Lift Time"
   },
   "special_bonus_unique_invoker_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Cold Snap Cooldown"
+    "dname": "-6s Cold Snap Cooldown"
   },
   "special_bonus_unique_invoker_10": {
     "dname": "+{s:bonus_damage_per_mana_pct}% E.M.P. Mana Burnt"
   },
   "special_bonus_unique_invoker_11": {
-    "dname": "-{s:bonus_AbilityCooldown}s Sun Strike Cooldown"
+    "dname": "-4s Sun Strike Cooldown"
   },
   "special_bonus_unique_invoker_12": {
     "dname": "Vector Target Ice Wall"
@@ -76727,91 +77014,94 @@
     "dname": "{s:bonus_intrinsic_attack_speed}x Quas/Wex/Exort passive effects"
   },
   "special_bonus_unique_invoker_13": {
-    "dname": "{s:bonus_move_speed_per_instance}x Quas/Wex/Exort Active Bonuses"
+    "dname": "2x Quas/Wex/Exort Active Bonuses"
   },
   "special_bonus_unique_invoker_ice_wall_dps": {
-    "dname": "+{s:bonus_damage_per_second} Ice Wall DPS"
+    "dname": "+50 Ice Wall DPS"
   },
   "special_bonus_unique_invoker_additional_chaos_meteors": {
-    "dname": "+{s:bonus_meteor_count} Chaos Meteors"
+    "dname": "+2 Chaos Meteors"
+  },
+  "special_bonus_unique_invoker_forged_spirit_armor_reduction": {
+    "dname": "+50% Forged Spirit Armor Reduction"
   },
   "special_bonus_unique_abaddon_borrowed_time_cd": {
-    "dname": "-{s:bonus_AbilityCooldown}s Borrowed Time Cooldown"
+    "dname": "-10s Borrowed Time Cooldown"
   },
   "special_bonus_unique_alchemist": {
-    "dname": "+{s:bonus_radius} Unstable Concoction Radius"
+    "dname": "+150 Unstable Concoction Radius"
   },
   "special_bonus_unique_alchemist_2": {
-    "dname": "+{s:bonus_max_damage} Unstable Concoction Max Damage"
+    "dname": "+400 Unstable Concoction Max Damage"
   },
   "special_bonus_unique_alchemist_3": {
     "dname": "Acid Spray grants armor to allies"
   },
   "special_bonus_unique_alchemist_4": {
-    "dname": "+{s:bonus_bonus_health_regen} Chemical Rage Regeneration"
+    "dname": "+50 Chemical Rage Regeneration"
   },
   "special_bonus_unique_alchemist_5": {
-    "dname": "+{s:bonus_armor_reduction} Acid Spray Armor Reduction"
+    "dname": "+1 Acid Spray Armor Reduction"
   },
   "special_bonus_unique_alchemist_6": {
-    "dname": "+{s:bonus_bonus_movespeed} Chemical Rage Movement Speed"
+    "dname": "+50 Chemical Rage Movement Speed"
   },
   "special_bonus_unique_alchemist_7": {
-    "dname": "Greevil's Greed provides +{s:bonus_damage} Damage per stack"
+    "dname": "Greevil's Greed provides +3 Damage per stack"
   },
   "special_bonus_unique_alchemist_8": {
-    "dname": "-{s:bonus_base_attack_time}s Chemical Rage Base Attack Time"
+    "dname": "-0.1s Chemical Rage Base Attack Time"
   },
   "special_bonus_unique_alchemist_weaponry_power": {
-    "dname": "+{s:bonus_slow_per_stack}% Corrosive Weaponry Slow / Damage Reduction Per Stack"
+    "dname": "+1% Corrosive Weaponry Slow / Damage Reduction Per Stack"
   },
   "special_bonus_unique_axe": {
-    "dname": "+{s:bonus_damage_per_second} Battle Hunger Damage Per Second"
+    "dname": "+8 Battle Hunger Damage Per Second"
   },
   "special_bonus_unique_axe_2": {
-    "dname": "+{s:bonus_radius} Berserker's Call AoE"
+    "dname": "+85 Berserker's Call AoE"
   },
   "special_bonus_unique_axe_3": {
     "dname": "+{s:bonus_armor_per_stack} Bonus Armor per Culling Blade Stack"
   },
   "special_bonus_unique_axe_4": {
-    "dname": "+{s:bonus_damage} Counter Helix Damage"
+    "dname": "+40 Counter Helix Damage"
   },
   "special_bonus_unique_axe_5": {
-    "dname": "+{s:bonus_damage} Culling Blade Damage"
+    "dname": "+150 Culling Blade Damage"
   },
   "special_bonus_unique_axe_6": {
     "dname": "+{s:bonus_slow}% Battle Hunger Slow"
   },
   "special_bonus_unique_axe_7": {
-    "dname": "+{s:bonus_bonus_armor} Berserker's Call Armor"
+    "dname": "+10 Berserker's Call Armor"
   },
   "special_bonus_unique_axe_8": {
-    "dname": "+{s:bonus_speed_bonus}% Movement Speed per active Battle Hunger"
+    "dname": "+8% Movement Speed per active Battle Hunger"
   },
   "special_bonus_unique_axe_helix_lifesteal": {
-    "dname": "{s:bonus_helix_lifesteal}% Counter Helix Lifesteal"
+    "dname": "30% Counter Helix Lifesteal"
   },
   "special_bonus_unique_axe_culling_blade_speed_duration": {
-    "dname": "+{s:bonus_speed_duration}s Culling Blade Kill Buff Bonus Duration"
+    "dname": "+3s Culling Blade Kill Buff Bonus Duration"
   },
   "special_bonus_unique_invoker_facet_orb_level": {
     "dname": "+{s:bonus_facet_bonus_levels} Facet Orb Level"
   },
   "special_bonus_unique_beastmaster_9": {
-    "dname": "+{s:bonus_damage_amp}% Wild Axes Damage Amp Per Stack"
+    "dname": "+1.5% Wild Axes Damage Amp Per Stack"
   },
   "special_bonus_unique_beastmaster_2": {
-    "dname": "+{s:bonus_boar_bonus_damage} Damage to Beastmaster and his summons"
+    "dname": "+30 Damage to Beastmaster and his summons"
   },
   "special_bonus_unique_beastmaster_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Call Of The Wild Cooldown"
+    "dname": "-5s Call Of The Wild Cooldown"
   },
   "special_bonus_unique_beastmaster_4": {
-    "dname": "+{s:bonus_AbilityCastRange} Primal Roar Cast Range"
+    "dname": "+200 Primal Roar Cast Range"
   },
   "special_bonus_unique_beastmaster_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Primal Roar Cooldown"
+    "dname": "-25s Primal Roar Cooldown"
   },
   "special_bonus_unique_beastmaster_8": {
     "dname": "Hawks Grant True Sight"
@@ -76820,7 +77110,7 @@
     "dname": "No Wild Axes Cooldown"
   },
   "special_bonus_unique_clinkz_1": {
-    "dname": "+{s:bonus_duration}s Strafe Duration"
+    "dname": "+1.0s Strafe Duration"
   },
   "special_bonus_unique_clinkz_2": {
     "dname": "Death Pact Steal creep abilities"
@@ -76832,7 +77122,7 @@
     "dname": "Searing Arrows Multishot"
   },
   "special_bonus_unique_clinkz_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Strafe Cooldown"
+    "dname": "-9s Strafe Cooldown"
   },
   "special_bonus_unique_clinkz_5": {
     "dname": "-{s:value}s Burning Army Cooldown"
@@ -76841,16 +77131,16 @@
     "dname": "+{s:value} Death Pact Health"
   },
   "special_bonus_unique_clinkz_7": {
-    "dname": "+{s:bonus_attack_speed_bonus} Strafe Attack Speed"
+    "dname": "+40 Strafe Attack Speed"
   },
   "special_bonus_unique_clinkz_8": {
-    "dname": "+{s:bonus_health_gain} Death Pact Bonus Health"
+    "dname": "+400 Death Pact Bonus Health"
   },
   "special_bonus_unique_clinkz_9": {
     "dname": "-{s:bonus_AbilityChargeRestoreTime}s Death Pact Charge Restore Time"
   },
   "special_bonus_unique_clinkz_10": {
-    "dname": "-{s:bonus_AbilityCooldown}s Skeleton Walk Cooldown"
+    "dname": "-4s Skeleton Walk Cooldown"
   },
   "special_bonus_unique_clinkz_11": {
     "dname": "Kills Reset Death Pact Cooldown"
@@ -76859,7 +77149,7 @@
     "dname": "+{s:value} Burning Barrage arrows"
   },
   "special_bonus_unique_juggernaut": {
-    "dname": "+{s:bonus_blade_fury_damage} Blade Fury DPS"
+    "dname": "+120 Blade Fury Damage Per Second"
   },
   "special_bonus_unique_juggernaut_omnislash_dispel": {
     "dname": "Omnislash Dispels the Enemy Every Hit"
@@ -76868,97 +77158,97 @@
     "dname": "+{s:bonus_AbilityCastRange} Omnislash Cast Range"
   },
   "special_bonus_unique_juggernaut_omnislash_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Omnislash Cooldown"
+    "dname": "-15s Omnislash Cooldown"
   },
   "special_bonus_unique_juggernaut_blade_form_agility_per_stack": {
     "dname": "+{s:bonus_agi_bonus_pct_per_stack}% Bladeform Base Agility Per Stack"
   },
   "special_bonus_unique_terrorblade": {
-    "dname": "-{s:bonus_AbilityCooldown}s Sunder Cooldown"
+    "dname": "-30s Sunder Cooldown"
   },
   "special_bonus_unique_terrorblade_2": {
-    "dname": "+{s:bonus_illusion_duration}s Reflection Duration"
+    "dname": "+1s Reflection Duration"
   },
   "special_bonus_unique_terrorblade_3": {
-    "dname": "+{s:bonus_duration}s Metamorphosis Duration"
+    "dname": "+30s Metamorphosis Duration"
   },
   "special_bonus_unique_terrorblade_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Conjure Image Cooldown"
+    "dname": "-2s Conjure Image Cooldown"
   },
   "special_bonus_unique_terrorblade_5": {
-    "dname": "+{s:bonus_illusion_duration}s Conjure Image Duration"
+    "dname": "+8s Conjure Image Duration"
   },
   "special_bonus_unique_terrorblade_6": {
-    "dname": "+{s:bonus_move_slow}% Reflection Slow/Damage"
+    "dname": "+15% Reflection Slow/Damage"
   },
   "special_bonus_unique_terrorblade_metamorphosis_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Metamorphosis Cooldown"
+    "dname": "-10s Metamorphosis Cooldown"
   },
   "special_bonus_unique_terrorblade_sunder_hp_threshold": {
-    "dname": "-{s:bonus_hit_point_minimum_pct}% Sunder Minimum HP Swap"
+    "dname": "-25% Sunder Minimum HP Swap"
   },
   "special_bonus_unique_luna_1": {
-    "dname": "+{s:bonus_beam_damage} Lucent Beam Damage"
+    "dname": "+80 Lucent Beam Damage"
   },
   "special_bonus_unique_luna_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Lucent Beam Cooldown"
+    "dname": "-2s Lucent Beam Cooldown"
   },
   "special_bonus_unique_luna_3": {
-    "dname": "+{s:bonus_bonus_damage}/{s:bonus_self_bonus_damage} Lunar Blessing Allied/Self Damage"
+    "dname": "+25/50 Lunar Blessing Allied/Self Damage"
   },
   "special_bonus_unique_luna_4": {
-    "dname": "+{s:bonus_stun_duration}s Lucent Beam Ministun"
+    "dname": "+0.5s Lucent Beam Ministun"
   },
   "special_bonus_unique_luna_5": {
     "dname": "Lucent Beam Hits An Additional Target"
   },
   "special_bonus_unique_luna_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Eclipse Cooldown"
+    "dname": "-40.0s Eclipse Cooldown"
   },
   "special_bonus_unique_luna_7": {
-    "dname": "-{s:bonus_damage_reduction_percent}% Moon Glaives Damage Reduction"
+    "dname": "-5% Moon Glaives Damage Reduction"
   },
   "special_bonus_unique_luna_8": {
-    "dname": "{s:bonus_glaives_fired} Moon Glaives fired on Lucent Beam"
+    "dname": "2 Moon Glaives fired on Lucent Beam"
   },
   "special_bonus_unique_luna_lunar_orbit_glaive_count": {
-    "dname": "+{s:bonus_rotating_glaives} Lunar Orbit Glaive"
+    "dname": "+1 Lunar Orbit Glaive"
   },
   "special_bonus_unique_luna_lunar_orbit_speed_damage": {
-    "dname": "{s:bonus_rotating_glaive_collision_speed_damage_tooltip}x Lunar Orbit Damage / Speed"
+    "dname": "1.5x Lunar Orbit Damage / Speed"
   },
   "special_bonus_unique_faceless_void": {
-    "dname": "+{s:bonus_bonus_attack_speed} Attack Speed during Chronosphere"
+    "dname": "+80 Attack Speed during Chronosphere"
   },
   "special_bonus_unique_faceless_void_2": {
-    "dname": "+{s:bonus_radius} Chronosphere AoE"
+    "dname": "+140 Chronosphere AoE"
   },
   "special_bonus_unique_faceless_void_3": {
-    "dname": "+{s:bonus_bonus_damage} Time Lock Damage"
+    "dname": "+35 Time Lock Damage"
   },
   "special_bonus_unique_faceless_void_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Time Walk Cooldown"
+    "dname": "-1.0s Time Walk Cooldown"
   },
   "special_bonus_unique_faceless_void_6": {
-    "dname": "+{s:bonus_damage_per_stack} Time Dilation DPS Per Cooldown"
+    "dname": "+6 Time Dilation DPS Per Cooldown"
   },
   "special_bonus_unique_faceless_void_7": {
-    "dname": "+{s:bonus_backtrack_duration}s Time Walk Backtrack Duration"
+    "dname": "+0.5s Time Walk Backtrack Duration"
   },
   "special_bonus_unique_faceless_void_8": {
-    "dname": "+{s:bonus_range} Time Walk Range"
+    "dname": "+125 Time Walk Range"
   },
   "special_bonus_unique_night_stalker": {
-    "dname": "-{s:bonus_AbilityCooldown}s Dark Ascension Cooldown"
+    "dname": "-35s Dark Ascension Cooldown"
   },
   "special_bonus_unique_night_stalker_2": {
-    "dname": "+{s:bonus_attack_heal} Midnight Feast Lifesteal"
+    "dname": "+100 Midnight Feast Lifesteal"
   },
   "special_bonus_unique_night_stalker_3": {
-    "dname": "+{s:bonus_bonus_damage} Dark Ascension Damage"
+    "dname": "+25 Dark Ascension Damage"
   },
   "special_bonus_unique_night_stalker_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Void Cooldown"
+    "dname": "-1s Void Cooldown"
   },
   "special_bonus_unique_night_stalker_5": {
     "dname": "+{s:bonus_bonus_movement_speed_pct_night}% Hunter In The Night Movement Speed"
@@ -76970,79 +77260,79 @@
     "dname": "+{s:bonus_duration}s Dark Ascension Duration"
   },
   "special_bonus_unique_night_stalker_hunter_status_resist": {
-    "dname": "{s:bonus_bonus_status_resist_night}% Hunter in the Night Status Resistance"
+    "dname": "20% Hunter in the Night Status Resistance"
   },
   "special_bonus_unique_night_stalker_crippling_fear_damage": {
-    "dname": "+{s:bonus_dps} Crippling Fear DPS"
+    "dname": "+10 Crippling Fear DPS"
   },
   "special_bonus_unique_night_stalker_crippling_fear_radius": {
-    "dname": "+{s:bonus_radius} Crippling Fear Radius"
+    "dname": "+75 Crippling Fear Radius"
   },
   "special_bonus_unique_night_stalker_midnight_feast_duration": {
     "dname": "+{s:bonus_heal_duration}s Midnight Feast Duration"
   },
   "special_bonus_unique_nyx": {
-    "dname": "{s:bonus_aoe} Mind Flare Radius"
+    "dname": "600 Mind Flare Radius"
   },
   "special_bonus_unique_nyx_2": {
-    "dname": "+{s:bonus_impale_damage} Impale Damage"
+    "dname": "+140 Impale Damage"
   },
   "special_bonus_unique_nyx_3": {
-    "dname": "+{s:bonus_duration}s Impale Stun Duration"
+    "dname": "+0.2s Impale Stun Duration"
   },
   "special_bonus_unique_nyx_4": {
-    "dname": "+{s:bonus_damage_reflect_pct}% Spiked Carapace Damage Reflect"
+    "dname": "+25% Spiked Carapace Damage Reflect"
   },
   "special_bonus_unique_nyx_5": {
     "dname": "Vendetta Has Unobstructed Movement"
   },
   "special_bonus_unique_nyx_6": {
-    "dname": "+{s:bonus_stun_duration}s Spiked Carapace Stun Duration"
+    "dname": "+0.6s Spiked Carapace Stun Duration"
   },
   "special_bonus_unique_nyx_carapace_reflect_duration": {
     "dname": "+{s:bonus_reflect_duration}s Spiked Carapace Reflect Duration"
   },
   "special_bonus_unique_nyx_vendetta_damage": {
-    "dname": "+{s:bonus_bonus_damage} Vendetta Damage"
+    "dname": "+50 Vendetta Damage"
   },
   "special_bonus_unique_nyx_vendetta_cd_manacost": {
     "dname": "Vendetta Applies Break"
   },
   "special_bonus_unique_nyx_jolt_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Mind Flare Cooldown"
+    "dname": "-3s Mind Flare Cooldown"
   },
   "special_bonus_unique_weaver_1": {
-    "dname": "+{s:bonus_damage} Shukuchi Damage"
+    "dname": "+90 Shukuchi Damage"
   },
   "special_bonus_unique_weaver_2": {
-    "dname": "+{s:bonus_bonus_damage} Bonus Damage On Geminate"
+    "dname": "+60 Bonus Damage On Geminate"
   },
   "special_bonus_unique_weaver_3": {
-    "dname": "+{s:bonus_armor_reduction} Swarm Armor Reduction Per Attack"
+    "dname": "+0.5 Swarm Armor Reduction Per Attack"
   },
   "special_bonus_unique_weaver_4": {
-    "dname": "+{s:bonus_destroy_attacks} Swarm Attacks to Kill"
+    "dname": "+2 Swarm Attacks to Kill"
   },
   "special_bonus_unique_weaver_5": {
-    "dname": "+{s:bonus_extra_attack} Geminate Attack"
+    "dname": "+1 Geminate Attack"
   },
   "special_bonus_unique_weaver_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Shukuchi Cooldown"
+    "dname": "-3s Shukuchi Cooldown"
   },
   "special_bonus_unique_weaver_shukuchi_movespeed": {
-    "dname": "+{s:bonus_min_movespeed_override} Shukuchi Movement Speed"
+    "dname": "+50 Shukuchi Movement Speed"
   },
   "special_bonus_unique_ursa": {
-    "dname": "+{s:bonus_damage_per_stack} Fury Swipes Damage"
+    "dname": "+6 Fury Swipes Damage"
   },
   "special_bonus_unique_ursa_2": {
-    "dname": "+{s:bonus_shock_radius} Earthshock Radius"
+    "dname": "+300 Earthshock Radius"
   },
   "special_bonus_unique_ursa_3": {
-    "dname": "Earthshock has {s:bonus_AbilityCharges} Charges"
+    "dname": "Earthshock has 2 Charges"
   },
   "special_bonus_unique_ursa_4": {
-    "dname": "+{s:bonus_bonus_reset_time}s Fury Swipes Reset Time"
+    "dname": "+9s Fury Swipes Reset Time"
   },
   "special_bonus_unique_ursa_5": {
     "dname": "+{s:value} AoE Earthshock"
@@ -77051,10 +77341,10 @@
     "dname": "Enrage gains {s:value}% Status Resistance"
   },
   "special_bonus_unique_ursa_7": {
-    "dname": "+{s:bonus_max_attacks} Overpower Attacks"
+    "dname": "+3 Overpower Attacks"
   },
   "special_bonus_unique_ursa_8": {
-    "dname": "+{s:bonus_status_resistance}% Enrage Status Resistance"
+    "dname": "+25% Enrage Status Resistance"
   },
   "special_bonus_unique_ursa_enrage_radius": {
     "dname": "Enrage provides half benefits to allies in a {s:bonus_aoe_radius} radius"
@@ -77063,46 +77353,46 @@
     "dname": "Earthshock Applies {s:bonus_fury_swipe_stacks_on_hit} Fury Swipes"
   },
   "special_bonus_unique_ursa_maul_health": {
-    "dname": "+{s:bonus_health_as_damage_pct}% Maul Health As Damage"
+    "dname": "+0.5% Maul Health As Damage"
   },
   "special_bonus_unique_chaos_knight": {
     "dname": "Reality Rift Pierces Spell Immunity"
   },
   "special_bonus_unique_chaos_knight_2": {
-    "dname": "+{s:bonus_pull_distance} Reality Rift Pull Distance"
+    "dname": "+225 Reality Rift Pull Distance"
   },
   "special_bonus_unique_chaos_knight_3": {
-    "dname": "+{s:bonus_stun_max} Min/Max Chaos Bolt Duration"
+    "dname": "+0.6 Min/Max Chaos Bolt Duration"
   },
   "special_bonus_unique_chaos_knight_4": {
     "dname": "+{s:bonus_illusion_duration}s Phantasm Duration"
   },
   "special_bonus_unique_chaos_knight_5": {
-    "dname": "+{s:bonus_chance}% Chaos Strike Chance"
+    "dname": "+10% Chaos Strike Chance"
   },
   "special_bonus_unique_chaos_knight_6": {
-    "dname": "+{s:bonus_lifesteal}% Chaos Strike Lifesteal"
+    "dname": "+30% Chaos Strike Lifesteal"
   },
   "special_bonus_unique_chaos_knight_7": {
-    "dname": "-{s:bonus_incoming_damage}% Phantasm Illusion Incoming Damage"
+    "dname": "-125% Phantasm Illusion Incoming Damage"
   },
   "special_bonus_unique_chaos_knight_8": {
-    "dname": "-{s:bonus_AbilityCooldown}s Chaos Bolt Cooldown"
+    "dname": "-3s Chaos Bolt Cooldown"
   },
   "special_bonus_unique_lycan_1": {
-    "dname": "+{s:bonus_duration}s Shapeshift Duration"
+    "dname": "+7s Shapeshift Duration"
   },
   "special_bonus_unique_lycan_2": {
     "dname": "-{s:bonus_wolf_bat}% Summon Wolves BAT"
   },
   "special_bonus_unique_lycan_3": {
-    "dname": "+{s:bonus_bonus_damage} Wolves Damage"
+    "dname": "+14 Wolves Damage"
   },
   "special_bonus_unique_lycan_3_facet_lycan_spirit_wolves": {
     "dname": "+{s:bonus_damage_per_wolf} Summon Wolves Damage Per Wolf"
   },
   "special_bonus_unique_lycan_4": {
-    "dname": "+{s:bonus_bonus_damage}% Feral Impulse Damage"
+    "dname": "+25% Feral Impulse Damage"
   },
   "special_bonus_unique_lycan_5": {
     "dname": "Howl Reduces Total Attack Damage"
@@ -77111,37 +77401,37 @@
     "dname": "+{s:bonus_attack_damage_reduction}% Howl Attack Damage Reduction"
   },
   "special_bonus_unique_lycan_7": {
-    "dname": "+{s:bonus_bonus_health} Summon Wolves Health"
+    "dname": "+375 Summon Wolves Health"
   },
   "special_bonus_unique_lycan_7_facet_lycan_spirit_wolves": {
     "dname": "+{s:bonus_health_per_wolf} Summon Wolves Health Per Wolf"
   },
   "special_bonus_unique_lycan_8": {
-    "dname": "-{s:bonus_AbilityCooldown}s Shapeshift Cooldown"
+    "dname": "-15s Shapeshift Cooldown"
   },
   "special_bonus_unique_lycan_howl_armor": {
-    "dname": "+{s:bonus_armor} Howl Armor Reduction"
+    "dname": "+3 Howl Armor Reduction"
   },
   "special_bonus_unique_windranger": {
     "dname": "+{s:bonus_radius} Windrun Radius"
   },
   "special_bonus_unique_windranger_2": {
-    "dname": "Focus Fire Kills Advance Cooldown by {s:bonus_cooldown_reduction_per_kill}s"
+    "dname": "Focus Fire Kills Advance Cooldown by 16s"
   },
   "special_bonus_unique_windranger_3": {
-    "dname": "-{s:bonus_damage_reduction}% Powershot Reduction"
+    "dname": "-15% Powershot Reduction"
   },
   "special_bonus_unique_windranger_4": {
-    "dname": "+{s:bonus_duration}s Windrun Duration"
+    "dname": "+0.75s Windrun Duration"
   },
   "special_bonus_unique_windranger_5": {
-    "dname": "+{s:bonus_max_movespeed} Tailwind Max Movespeed"
+    "dname": "+40 Tailwind Max Movespeed"
   },
   "special_bonus_unique_windranger_6": {
-    "dname": "+{s:bonus_stun_duration}s Shackleshot Duration"
+    "dname": "+0.75s Shackleshot Duration"
   },
   "special_bonus_unique_windranger_7": {
-    "dname": "Powershot Executes Enemy Heroes Under {s:bonus_max_execute_threshold}% Max HP"
+    "dname": "Powershot Executes Enemy Heroes Under 16% Max HP"
   },
   "special_bonus_unique_windranger_8": {
     "dname": "-{s:bonus_focusfire_damage_reduction}% Focus Fire Damage Reduction"
@@ -77156,7 +77446,7 @@
     "dname": "Windrun Cannot Be Dispelled"
   },
   "special_bonus_unique_windranger_powershot_slow": {
-    "dname": "+{s:bonus_slow_duration}s Powershot Slow Duration"
+    "dname": "+1s Powershot Slow Duration"
   },
   "special_bonus_unique_windranger_powershot_dmg": {
     "dname": "+{s:bonus_powershot_damage} Powershot Damage"
@@ -77171,10 +77461,10 @@
     "dname": "+{s:value} Max Juxtapose Illusions"
   },
   "special_bonus_unique_phantom_lancer_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Doppelganger Cooldown"
+    "dname": "-4s Doppelganger Cooldown"
   },
   "special_bonus_unique_phantom_lancer_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Spirit Lance Cooldown"
+    "dname": "-1s Spirit Lance Cooldown"
   },
   "special_bonus_unique_phantom_lancer_6": {
     "dname": "+{s:bonus_tooltip_illusion_damage}% Juxtapose Damage"
@@ -77186,7 +77476,7 @@
     "dname": "+{s:bonus_illusion_2_amount} Doppelganger Illusion"
   },
   "special_bonus_unique_phantom_lancer_lance_slow_duration": {
-    "dname": "+{s:bonus_duration}s Spirit Lance Slow Duration"
+    "dname": "+1.0s Spirit Lance Slow Duration"
   },
   "special_bonus_unique_phantom_lancer_phantom_rush_duration": {
     "dname": "+{s:bonus_duration}s Phantom Rush Debuff Duration"
@@ -77195,97 +77485,97 @@
     "dname": "+{s:bonus_bonus_agility} Phantom Rush Agility"
   },
   "special_bonus_unique_phantom_lancer_phantom_rush_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown} Phantom Rush Cooldown"
+    "dname": "-2 Phantom Rush Cooldown"
   },
   "special_bonus_unique_phantom_lancer_illusory_armaments_duration": {
-    "dname": "+{s:bonus_duration}s Illusory Armaments Duration"
+    "dname": "+2s Illusory Armaments Duration"
   },
   "special_bonus_unique_phantom_lancer_lance_illusion_damage": {
     "dname": "+{s:bonus_tooltip_illusion_damage}% Spirit Lance Illusion Damage"
   },
   "special_bonus_unique_phantom_lancer_illusion_lances": {
-    "dname": "{s:bonus_illusion_lance_damage_pct}% Illusion Spirit Lance Damage"
+    "dname": "50% Illusion Spirit Lance Damage"
   },
   "special_bonus_unique_phantom_lancer_juxtapose_illusio_proc_chance": {
-    "dname": "+{s:bonus_illusion_proc_chance_pct}% Juxtapose Illusion Trigger Chance"
+    "dname": "+3% Juxtapose Illusion Trigger Chance"
   },
   "special_bonus_unique_phantom_lancer_juxtapose_damage_in": {
-    "dname": "-{s:bonus_illusion_damage_in_pct}% Juxtapose Illusion Damage Taken"
+    "dname": "-70% Juxtapose Illusion Damage Taken"
   },
   "special_bonus_unique_phantom_lancer_lance_damage": {
-    "dname": "+{s:bonus_lance_damage} Spirit Lance Damage"
+    "dname": "+100 Spirit Lance Damage"
   },
   "special_bonus_unique_phantom_lancer_doppelwalk_cast_range": {
-    "dname": "+{s:bonus_AbilityCastRange} Doppelganger Cast Range"
+    "dname": "+125 Doppelganger Cast Range"
   },
   "special_bonus_unique_slark": {
-    "dname": "+{s:bonus_leash_duration}s Pounce Leash"
+    "dname": "+0.5s Pounce Leash"
   },
   "special_bonus_unique_slark_2": {
-    "dname": "+{s:bonus_total_damage} Dark Pact Damage"
+    "dname": "+70 Dark Pact Damage"
   },
   "special_bonus_unique_slark_3": {
-    "dname": "+{s:bonus_duration}s Shadow Dance Duration"
+    "dname": "+1.5s Shadow Dance Duration"
   },
   "special_bonus_unique_slark_4": {
-    "dname": "+{s:bonus_duration}s Essence Shift Duration"
+    "dname": "+20s Essence Shift Duration"
   },
   "special_bonus_unique_slark_5": {
-    "dname": "+{s:bonus_agi_gain} Agility gain/stolen per Essence Shift Stack"
+    "dname": "+1 Agility gain/stolen per Essence Shift Stack"
   },
   "special_bonus_unique_slark_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Dark Pact Cooldown"
+    "dname": "-0.75s Dark Pact Cooldown"
   },
   "special_bonus_unique_slark_7": {
-    "dname": "+{s:bonus_attack_speed} Shadow Dance Attack Speed"
+    "dname": "+100 Shadow Dance Attack Speed"
   },
   "special_bonus_unique_slark_8": {
-    "dname": "+{s:bonus_bonus_regen} Shadow Dance Regen"
+    "dname": "+30 Shadow Dance Regen"
   },
   "special_bonus_unique_spectre": {
-    "dname": "-{s:bonus_AbilityCooldown}s Spectral Dagger Cooldown"
+    "dname": "-3s Spectral Dagger Cooldown"
   },
   "special_bonus_unique_spectre_2": {
-    "dname": "+{s:bonus_bonus_damage} Desolate Damage"
+    "dname": "+12 Desolate Damage"
   },
   "special_bonus_unique_spectre_3": {
-    "dname": "+{s:bonus_bonus_movespeed}% Spectral Dagger Slow/Bonus"
+    "dname": "+15% Spectral Dagger Slow/Bonus"
   },
   "special_bonus_unique_spectre_4": {
-    "dname": "+{s:bonus_illusion_damage_outgoing}% All Spectre Illusion Damage"
+    "dname": "+15% All Spectre Illusion Damage"
   },
   "special_bonus_unique_spectre_5": {
-    "dname": "+{s:bonus_damage_reflection_pct}% Dispersion"
+    "dname": "+4% Dispersion"
   },
   "special_bonus_unique_spectre_6": {
-    "dname": "+{s:bonus_damage} Spectral Dagger Damage"
+    "dname": "+80 Spectral Dagger Damage"
   },
   "special_bonus_unique_spectre_desolate_radius": {
     "dname": "-{s:bonus_radius} Desolate Ally Radius"
   },
   "special_bonus_unique_spirit_breaker_1": {
-    "dname": "-{s:bonus_AbilityCooldown}s Greater Bash Cooldown"
+    "dname": "-0.3s Greater Bash Cooldown"
   },
   "special_bonus_unique_spirit_breaker_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Bulldoze Cooldown"
+    "dname": "-3s Bulldoze Cooldown"
   },
   "special_bonus_unique_spirit_breaker_3": {
-    "dname": "+{s:bonus_damage}% Greater Bash Damage"
+    "dname": "+20% Greater Bash Damage"
   },
   "special_bonus_unique_spirit_breaker_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Charge of Darkness Cooldown"
+    "dname": "-4s Charge of Darkness Cooldown"
   },
   "special_bonus_unique_spirit_breaker_shield": {
-    "dname": "Bulldoze {s:bonus_damage_barrier} All Damage Barrier"
+    "dname": "Bulldoze 375 All Damage Barrier"
   },
   "special_bonus_unique_spirit_breaker_increased_charge_speed": {
-    "dname": "+{s:bonus_movement_speed} Charge of Darkness Bonus Speed"
+    "dname": "+60 Charge of Darkness Bonus Speed"
   },
   "special_bonus_unique_bull_rush_movement_increase": {
-    "dname": "+{s:bonus_hero_movespeed_percent}%/+{s:bonus_creep_movespeed_percent}% Empowering Haste Movespeed Bonus"
+    "dname": "+8%/+2% Empowering Haste Movespeed Bonus"
   },
   "special_bonus_unique_storm_spirit": {
-    "dname": "+{s:bonus_AbilityDuration}s Electric Vortex Duration"
+    "dname": "+0.2s Electric Vortex Duration"
   },
   "special_bonus_unique_storm_spirit_2": {
     "dname": "+{s:value} Ball Lightning Damage"
@@ -77294,43 +77584,43 @@
     "dname": "Overload Pierces Immunity"
   },
   "special_bonus_unique_storm_spirit_4": {
-    "dname": "{s:bonus_auto_remnant_interval} Distance Auto Remnant in Ball Lightning"
+    "dname": "450 Distance Auto Remnant in Ball Lightning"
   },
   "special_bonus_unique_storm_spirit_5": {
-    "dname": "+{s:bonus_static_remnant_damage} Static Remnant Damage"
+    "dname": "+60 Static Remnant Damage"
   },
   "special_bonus_unique_storm_spirit_6": {
     "dname": "+{s:value} Overload Damage"
   },
   "special_bonus_unique_storm_spirit_7": {
-    "dname": "{s:bonus_overload_bounces}x Overload Attack Bounce"
+    "dname": "=2x Overload Attack Bounce"
   },
   "special_bonus_unique_storm_spirit_8": {
-    "dname": "-{s:bonus_AbilityCooldown}s Static Remnant Cooldown"
+    "dname": "-1.25s Static Remnant Cooldown"
   },
   "special_bonus_unique_storm_spirit_overload_aspd": {
-    "dname": "-{s:bonus_overload_move_slow} Overload Attack/Movement Speed Slow"
+    "dname": "+25.0/25.0% Overload Attack/Movement Speed Slow"
   },
   "special_bonus_unique_tidehunter": {
-    "dname": "-{s:bonus_negative_armor} Gush Armor"
+    "dname": "-4 Gush Armor"
   },
   "special_bonus_unique_tidehunter_2": {
-    "dname": "+{s:bonus_gush_damage} Gush Damage"
+    "dname": "+90 Gush Damage"
   },
   "special_bonus_unique_tidehunter_3": {
-    "dname": "+{s:bonus_damage_reduction}% Anchor Smash Damage Reduction"
+    "dname": "+10% Anchor Smash Damage Reduction"
   },
   "special_bonus_unique_tidehunter_4": {
     "dname": "+{s:bonus_bonus_reduction_per_stack} Kraken Shell Damage Block per Anchor Smash Kill"
   },
   "special_bonus_unique_tidehunter_5": {
-    "dname": "+{s:bonus_movement_speed}% Gush Slow"
+    "dname": "+20% Gush Slow"
   },
   "special_bonus_unique_tidehunter_6": {
     "dname": "-{s:bonus_damage_cleanse} Kraken Shell Damage Threshold"
   },
   "special_bonus_unique_tidehunter_7": {
-    "dname": "+{s:bonus_duration}s Ravage Stun Duration"
+    "dname": "+1.0s Ravage Stun Duration"
   },
   "special_bonus_unique_tidehunter_8": {
     "dname": "50% chance of Anchor Smash on attack"
@@ -77341,8 +77631,11 @@
   "special_bonus_unique_tidehunter_10": {
     "dname": "Anchor Smash affects buildings"
   },
+  "special_bonus_unique_tidehunter_10_description": {
+    "dname": "Deals {s:bonus_building_pct_damage}% damage to buildings."
+  },
   "special_bonus_unique_tidehunter_ravage_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Ravage Cooldown"
+    "dname": "-15s Ravage Cooldown"
   },
   "special_bonus_unique_tidehunter_smash_on_blubber": {
     "dname": "Kraken Shell Cleanse triggers Anchor Smash"
@@ -77351,7 +77644,7 @@
     "dname": "Triggered attack has {s:bonus_smash_on_purge}% damage and is reflected damage."
   },
   "special_bonus_unique_tinker": {
-    "dname": "+{s:bonus_laser_damage} Laser Damage"
+    "dname": "+50 Laser Damage"
   },
   "special_bonus_unique_tinker_2": {
     "dname": "+{s:value} March of the Machines Damage"
@@ -77360,10 +77653,10 @@
     "dname": "+{s:bonus_barrier_duration}s Defense Matrix Duration"
   },
   "special_bonus_unique_tinker_4": {
-    "dname": "{s:bonus_radius_explosion} AoE Laser"
+    "dname": "250 AoE Laser"
   },
   "special_bonus_unique_tinker_5": {
-    "dname": "-{s:bonus_AbilityChannelTime}s Keen Conveyance Channel Time"
+    "dname": "-0.5s Keen Conveyance Channel Time"
   },
   "special_bonus_unique_tinker_6": {
     "dname": "+{s:value} Heat-Seeking Missile Count"
@@ -77384,10 +77677,10 @@
     "dname": "+{s:bonus_drop_damage} Deploy Turrets Impact Damage"
   },
   "special_bonus_unique_tinker_deploy_turrets_knockback": {
-    "dname": "+{s:bonus_drop_knockback_distance_tinker} Deploy Turrets Tinker Knockback"
+    "dname": "+100 Deploy Turrets Tinker Knockback"
   },
   "special_bonus_unique_tinker_deploy_turrets_turret_duration": {
-    "dname": "+{s:bonus_turret_duration} Deploy Turret Duration"
+    "dname": "+1.5 Deploy Turret Duration"
   },
   "special_bonus_unique_tinker_deploy_turrets_splash_radius": {
     "dname": "Deploy Turrets Missile Splash Damage"
@@ -77396,37 +77689,37 @@
     "dname": "Missiles deal {s:bonus_splash_pct}% splash damage in a {s:bonus_radius_explosion} AoE"
   },
   "special_bonus_unique_tinker_deploy_turrets_missile_damage": {
-    "dname": "+{s:bonus_missile_damage} Deploy Turrets Missile Damage"
+    "dname": "+60 Deploy Turrets Missile Damage"
   },
   "special_bonus_unique_tinker_rearm_magic_resistance": {
     "dname": "Rearm Grants {s:bonus_magic_resistance}% Bonus Magic Resistance"
   },
   "special_bonus_unique_tinker_rearm_channel_time": {
-    "dname": "-{s:bonus_AbilityChannelTime}s Time to Rearm"
+    "dname": "-0.25s Time to Rearm"
   },
   "special_bonus_unique_tinker_march_duration": {
-    "dname": "+{s:bonus_duration}s March of the Machines Duration"
+    "dname": "+1.0s March of the Machines Duration"
   },
   "special_bonus_unique_tiny": {
-    "dname": "+{s:bonus_avalanche_damage} Avalanche Damage"
+    "dname": "+90 Avalanche Damage"
   },
   "special_bonus_unique_tiny_2": {
-    "dname": "{s:bonus_AbilityCharges} Toss Charges"
+    "dname": "2 Toss Charges"
   },
   "special_bonus_unique_tiny_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Avalanche Cooldown"
+    "dname": "-8s Avalanche Cooldown"
   },
   "special_bonus_unique_tiny_4": {
-    "dname": "+{s:bonus_AbilityCastRange} Avalanche Cast Range"
+    "dname": "+150 Avalanche Cast Range"
   },
   "special_bonus_unique_tiny_5": {
     "dname": "Toss Requires No Target"
   },
   "special_bonus_unique_tiny_6": {
-    "dname": "-{s:bonus_attack_speed_reduction}% Grow Attack Speed Reduction"
+    "dname": "+2 Tree Grab Attacks"
   },
   "special_bonus_unique_tiny_7": {
-    "dname": "+{s:bonus_bonus_damage} Tree Grab Base Damage"
+    "dname": "+60 Tree Grab Base Damage"
   },
   "special_bonus_unique_tiny_tree_no_limit": {
     "dname": "Tree Grab No Charge Limit"
@@ -77435,19 +77728,19 @@
     "dname": "+{s:bonus_attack_count} Tree Grab Attacks"
   },
   "special_bonus_unique_troll_warlord": {
-    "dname": "+{s:bonus_trance_duration}s Battle Trance Duration"
+    "dname": "+1s Battle Trance Duration"
   },
   "special_bonus_unique_troll_warlord_2": {
-    "dname": "+{s:bonus_bonus_move_speed} Berserker's Rage Movement Speed"
+    "dname": "+20 Berserker's Rage Movement Speed"
   },
   "special_bonus_unique_troll_warlord_3": {
-    "dname": "+{s:bonus_axe_damage} Whirling Axes Damage"
+    "dname": "+160 Whirling Axes Damage"
   },
   "special_bonus_unique_troll_warlord_4": {
     "dname": "Battle Trance Strong Dispels"
   },
   "special_bonus_unique_troll_warlord_5": {
-    "dname": "+{s:bonus_attack_speed} Fervor Attack Speed"
+    "dname": "+4 Fervor Attack Speed"
   },
   "special_bonus_unique_troll_warlord_6": {
     "dname": "Whirling Axes Pierce Magic Immunity"
@@ -77456,46 +77749,46 @@
     "dname": "-{s:value}s Battle Trance Cooldown"
   },
   "special_bonus_unique_troll_warlord_whirling_axes_debuff_duration": {
-    "dname": "+{s:bonus_axe_slow_duration}s Whirling Axes Debuff Duration"
+    "dname": "+2.5s Whirling Axes Debuff Duration"
   },
   "special_bonus_unique_troll_warlord_battle_trance_movespeed": {
     "dname": "Allies Receive Battle Trance Attack Speed"
   },
   "special_bonus_unique_undying": {
-    "dname": "+{s:bonus_zombie_damage_tooltip} Zombie Damage"
+    "dname": "+20 Zombie Damage"
   },
   "special_bonus_unique_undying_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Decay Cooldown"
+    "dname": "-2s Decay Cooldown"
   },
   "special_bonus_unique_undying_4": {
-    "dname": "+{s:bonus_str_percentage}% Flesh Golem Strength Bonus"
+    "dname": "+50% Flesh Golem Strength Bonus"
   },
   "special_bonus_unique_undying_5": {
-    "dname": "+{s:bonus_hits_to_destroy_tooltip} Tombstone Attacks to Destroy"
+    "dname": "+4 Tombstone Attacks to Destroy"
   },
   "special_bonus_unique_undying_6": {
-    "dname": "+{s:bonus_damage_per_unit} Soul Rip Damage/Heal"
+    "dname": "+12 Soul Rip Damage/Heal"
   },
   "special_bonus_unique_undying_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Tombstone Cooldown"
+    "dname": "-15s Tombstone Cooldown"
   },
   "special_bonus_unique_undying_8": {
-    "dname": "+{s:bonus_decay_damage} Decay Damage"
+    "dname": "+30 Decay Damage"
   },
   "special_bonus_unique_undying_flesh_golem_cooldown": {
     "dname": "-{s:bonus_AbilityCooldown} Flesh Golem Cooldown"
   },
   "special_bonus_unique_viper_1": {
-    "dname": "+{s:bonus_damage} Corrosive Skin Damage Per Second"
+    "dname": "+15 Corrosive Skin Damage Per Second"
   },
   "special_bonus_unique_viper_2": {
-    "dname": "+{s:bonus_damage} Viper Strike DPS"
+    "dname": "+70 Viper Strike DPS"
   },
   "special_bonus_unique_viper_3": {
-    "dname": "+{s:bonus_min_damage}/{s:bonus_max_damage} Nethertoxin Min/Max Damage"
+    "dname": "+20/40 Nethertoxin Min/Max Damage"
   },
   "special_bonus_unique_viper_4": {
-    "dname": "+{s:bonus_duration}s Viper Strike Duration"
+    "dname": "+1s Viper Strike Duration"
   },
   "special_bonus_unique_viper_5": {
     "dname": "Become Universal"
@@ -77504,70 +77797,70 @@
     "dname": "+{s:bonus_bonus_attack_speed} Corrosive Skin Attack Speed Slow"
   },
   "special_bonus_unique_viper_7": {
-    "dname": "+{s:bonus_damage}% Poison Attack Slow / Damage"
+    "dname": "+15% Poison Attack Slow / Damage"
   },
   "special_bonus_unique_viper_8": {
-    "dname": "-{s:bonus_AbilityCooldown}% Viper Strike Mana Cost / Cooldown"
+    "dname": "-50% Viper Strike Mana Cost / Cooldown"
   },
   "special_bonus_unique_viper_predator_damage": {
-    "dname": "+{s:bonus_damage} Predator Damage Per Missing Health"
+    "dname": "+0.35 Predator Damage Per Missing Health"
   },
   "special_bonus_unique_viper_nethertoxin_radius": {
-    "dname": "Nethertoxin Radius increases by {s:bonus_radius_increase} every {s:bonus_expand_interval}s"
+    "dname": "Nethertoxin Radius increases by 25 every 0.5s"
   },
   "special_bonus_unique_zeus": {
-    "dname": "+{s:bonus_targets} Heavenly Jump Target"
+    "dname": "+1 Heavenly Jump Target"
   },
   "special_bonus_unique_zeus_2": {
-    "dname": "+{s:bonus_arc_damage} Arc Lightning Damage"
+    "dname": "+60 Arc Lightning Damage"
   },
   "special_bonus_unique_zeus_3": {
-    "dname": "+{s:bonus_ministun_duration}s Lightning Bolt Ministun"
+    "dname": "+0.5s Lightning Bolt Ministun"
   },
   "special_bonus_unique_zeus_4": {
-    "dname": "+{s:bonus_damage} Thundergod's Wrath Damage"
+    "dname": "+75 Thundergod's Wrath Damage"
   },
   "special_bonus_unique_zeus_5": {
-    "dname": "{s:bonus_aoe_radius} AoE Lightning Bolt"
+    "dname": "325 AoE Lightning Bolt"
   },
   "special_bonus_unique_zeus_6": {
-    "dname": "-{s:bonus_AbilityCooldown}% Arc Lightning Mana Cost / Cooldown"
+    "dname": "-20% Arc Lightning Mana Cost / Cooldown"
   },
   "special_bonus_unique_zeus_jump_charges": {
-    "dname": "{s:bonus_AbilityCharges} Heavenly Jump Charges"
+    "dname": "3 Heavenly Jump Charges"
   },
   "special_bonus_unique_zeus_static_field_dmg": {
-    "dname": "+{s:bonus_damage_health_pct}% Static Field Damage"
+    "dname": "+2% Static Field Damage"
   },
   "special_bonus_unique_elder_titan": {
-    "dname": "+{s:bonus_damage_heroes} Astral Spirit Bonus Damage per Hero"
+    "dname": "+30 Astral Spirit Bonus Damage per Hero"
   },
   "special_bonus_unique_elder_titan_2": {
-    "dname": "+{s:bonus_stomp_damage} Echo Stomp Damage"
+    "dname": "+75 Echo Stomp Damage"
   },
   "special_bonus_unique_elder_titan_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Earth Splitter Cooldown"
+    "dname": "-60s Earth Splitter Cooldown"
   },
   "special_bonus_unique_elder_titan_4": {
-    "dname": "+{s:bonus_wake_damage_limit} Echo Stomp Wake Damage"
+    "dname": "+150 Echo Stomp Wake Damage"
   },
   "special_bonus_unique_elder_titan_5": {
-    "dname": "+{s:bonus_radius} Natural Order Radius"
+    "dname": "+150 Natural Order Radius"
   },
   "special_bonus_unique_elder_titan_bonus_spirit_speed": {
-    "dname": "+{s:bonus_move_pct_heroes}% Astral Spirit Bonus Move Speed Per Hero"
+    "dname": "+2.5% Astral Spirit Bonus Move Speed Per Hero"
   },
   "special_bonus_unique_elder_titan_spirit_damage": {
     "dname": "+{s:bonus_pass_damage} Astral Spirit Damage"
   },
   "special_bonus_unique_elder_titan_momentum_attack_speed": {
-    "dname": "{s:bonus_attack_speed_from_movespeed}% of Bonus Movement Speed as Attack Speed"
+    "dname": "20% of Bonus Movement Speed as Attack Speed"
   },
   "special_bonus_unique_ember_spirit_7": {
     "dname": "+{s:bonus_unit_count} Searing Chains Target"
   },
   "special_bonus_unique_lifestealer": {
-    "dname": "+{s:bonus_duration}s Rage Duration"
+    "dname": "+1.0s Rage Duration"
   },
   "special_bonus_unique_lifestealer_Facet_life_stealer_rage_dispell": {
     "dname": "+{s:bonus_duration}s Unfettered Duration"
@@ -77576,16 +77869,16 @@
     "dname": "+{s:bonus_movement_speed_bonus}% Ghoul Frenzy Movement Speed"
   },
   "special_bonus_unique_lifestealer_3": {
-    "dname": "+{s:bonus_hp_damage_percent}% Feast Heal and Damage"
+    "dname": "+1.0% Feast Heal and Damage"
   },
   "special_bonus_unique_lifestealer_4": {
-    "dname": "{s:bonus_attack_speed_on_target} Attack Speed on Open Wounds Target"
+    "dname": "50 Attack Speed on Open Wounds Target"
   },
   "special_bonus_unique_lifestealer_5": {
     "dname": "+{s:bonus_attack_speed_bonus} Ghoul Frenzy Attack Speed"
   },
   "special_bonus_unique_lifestealer_6": {
-    "dname": "+{s:bonus_heal_percent}% Open Wounds Lifesteal"
+    "dname": "+25% Open Wounds Lifesteal"
   },
   "special_bonus_unique_lifestealer_7": {
     "dname": "+{s:bonus_attack_speed_bonus} Ghoul Frenzy Attack Speed"
@@ -77594,40 +77887,40 @@
     "dname": "{s:bonus_miss_pct}% Miss Chance on Ghoul Frenzy"
   },
   "special_bonus_unique_lifestealer_infest_damage": {
-    "dname": "+{s:bonus_damage} Infest Damage"
+    "dname": "+175 Infest Damage"
   },
   "special_bonus_unique_lifestealer_infest_target_bonus": {
-    "dname": "+{s:bonus_bonus_movement_speed}% Infest Target Movespeed/Health"
+    "dname": "+12% Infest Target Movespeed/Health"
   },
   "special_bonus_unique_lifestealer_rage_armor": {
     "dname": "+{s:bonus_bonus_armor} Armor during Rage"
   },
   "special_bonus_unique_lifestealer_rage_movespeed": {
-    "dname": "+{s:bonus_movespeed_bonus}% Movespeed during Rage"
+    "dname": "+=8% Movespeed during Rage"
   },
   "special_bonus_unique_lion": {
     "dname": "+{s:value} Mana Drain Multi Target"
   },
   "special_bonus_unique_lion_2": {
-    "dname": "+{s:bonus_AbilityCastRange} Earth Spike cast range/travel distance"
+    "dname": "+600 Earth Spike cast range/travel distance"
   },
   "special_bonus_unique_lion_3": {
     "dname": "Fist of Death"
   },
   "special_bonus_unique_lion_4": {
-    "dname": "+{s:bonus_radius} AoE Hex"
+    "dname": "+250 AoE Hex"
   },
   "special_bonus_unique_lion_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Hex Cooldown"
+    "dname": "-2.0s Hex Cooldown"
   },
   "special_bonus_unique_lion_6": {
-    "dname": "+{s:bonus_movespeed}% Mana Drain Slow"
+    "dname": "+10% Mana Drain Slow"
   },
   "special_bonus_unique_lion_7": {
     "dname": "-{s:value}s Earth Spike Cooldown"
   },
   "special_bonus_unique_lion_8": {
-    "dname": "+{s:bonus_damage_per_kill} Finger of Death Damage Per Kill"
+    "dname": "+20 Finger of Death Damage Per Kill"
   },
   "special_bonus_unique_lion_9": {
     "dname": "-{s:value} Mana Drain Attack Speed"
@@ -77636,52 +77929,52 @@
     "dname": "Earth Spike affects a 30 degree cone"
   },
   "special_bonus_unique_lion_11": {
-    "dname": "+{s:bonus_spell_amp}% To Hell And Back Debuff/Spell Amp"
+    "dname": "+15% To Hell And Back Debuff/Spell Amp"
   },
   "special_bonus_unique_lion_manadrain_damage": {
     "dname": "+{s:bonus_damage_pct}% Mana Drain Damage"
   },
   "special_bonus_unique_skywrath": {
-    "dname": "-{s:bonus_AbilityCooldown}s Ancient Seal Cooldown"
+    "dname": "-6s Ancient Seal Cooldown"
   },
   "special_bonus_unique_skywrath_2": {
-    "dname": "+{s:bonus_int_multiplier}x Arcane Bolt Int Multiplier"
+    "dname": "+1.5x Arcane Bolt Int Multiplier"
   },
   "special_bonus_unique_skywrath_3": {
-    "dname": "+{s:bonus_resist_debuff}% Ancient Seal Increased Magic Damage"
+    "dname": "+10% Ancient Seal Increased Magic Damage"
   },
   "special_bonus_unique_skywrath_4": {
     "dname": "Global Concussive Shot"
   },
   "special_bonus_unique_skywrath_5": {
-    "dname": "+{s:bonus_damage} Mystic Flare Damage"
+    "dname": "+400 Mystic Flare Damage"
   },
   "special_bonus_unique_skywrath_6": {
-    "dname": "+{s:bonus_AbilityCastRange} Arcane Bolt Cast Range"
+    "dname": "+125 Arcane Bolt Cast Range"
   },
   "special_bonus_unique_skywrath_7": {
     "dname": "{s:value} AoE Ancient Seal"
   },
   "special_bonus_unique_skywrath_arcane_bolt_lifesteal": {
-    "dname": "+{s:bonus_spell_lifesteal}% Ruin and Restoration Spell Lifesteal"
+    "dname": "+20% Ruin and Restoration Spell Lifesteal"
   },
   "special_bonus_unique_skywrath_concussive_shot_slow": {
-    "dname": "+{s:bonus_movement_speed_pct}% Concussive Shot Slow"
+    "dname": "+20% Concussive Shot Slow"
   },
   "special_bonus_unique_medusa": {
-    "dname": "+{s:bonus_duration}s Stone Gaze Duration"
+    "dname": "+2.5s Stone Gaze Duration"
   },
   "special_bonus_unique_medusa_2": {
-    "dname": "+{s:bonus_damage_modifier}% Split Shot Outgoing Damage"
+    "dname": "+12% Split Shot Outgoing Damage"
   },
   "special_bonus_unique_medusa_3": {
-    "dname": "+{s:bonus_snake_jumps} Mystic Snake Bounces"
+    "dname": "+3 Mystic Snake Bounces"
   },
   "special_bonus_unique_medusa_4": {
     "dname": "Split Shot Uses Modifiers"
   },
   "special_bonus_unique_medusa_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Mystic Snake Cooldown"
+    "dname": "-4s Mystic Snake Cooldown"
   },
   "special_bonus_unique_medusa_6": {
     "dname": "+{s:bonus_damage_per_mana} Mana Shield Damage per Mana"
@@ -77690,37 +77983,37 @@
     "dname": "+{s:bonus_movement_slow}% Mystic Snake Turn and Movement Speed Slow"
   },
   "special_bonus_unique_medusa_8": {
-    "dname": "+{s:bonus_bonus_physical_damage}% Stone Gaze Bonus Physical Damage"
+    "dname": "+12% Stone Gaze Bonus Physical Damage"
   },
   "special_bonus_unique_medusa_snake_damage": {
-    "dname": "+{s:bonus_snake_damage}% Mystic Snake Damage / Mana Gain"
+    "dname": "+40% Mystic Snake Damage / Mana Gain"
   },
   "special_bonus_unique_medusa_stone_gaze_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}% Stone Gaze Cooldown and Mana Cost"
+    "dname": "-50% Stone Gaze Cooldown and Mana Cost"
   },
   "special_bonus_unique_medusa_gorgons_grasp_volleys": {
-    "dname": "+{s:bonus_volley_count} Gorgon's Grasp Volley"
+    "dname": "+1 Gorgon's Grasp Volley"
   },
   "special_bonus_unique_medusa_gorgons_grasp_radius": {
-    "dname": "+{s:bonus_radius}% Gorgon's Grasp Radius"
+    "dname": "+20% Gorgon's Grasp Radius"
   },
   "special_bonus_unique_ogre_magi": {
-    "dname": "+{s:bonus_bonus_attack_speed}/{s:bonus_self_bonus} Bloodlust / Self Attack Speed"
+    "dname": "+20/35 Bloodlust / Self Attack Speed"
   },
   "special_bonus_unique_ogre_magi_2": {
-    "dname": "+{s:bonus_fireblast_damage} Fireblast Damage"
+    "dname": "+175 Fireblast Damage"
   },
   "special_bonus_unique_ogre_magi_4": {
-    "dname": "+{s:bonus_burn_damage} Ignite Burn Damage"
+    "dname": "+10 Ignite Burn Damage"
   },
   "special_bonus_unique_ogre_magi_5": {
     "dname": "-{s:bonus_AbilityCooldown}s Fireblast Cooldown"
   },
   "special_bonus_unique_ogre_magi_dumb_luck_mana": {
-    "dname": "+{s:bonus_mana_per_str}/{s:bonus_mana_regen_per_str} Dumb Luck Mana/Mana Regen Per Strength"
+    "dname": "+2/0.01 Dumb Luck Mana/Mana Regen Per Strength"
   },
   "special_bonus_unique_ogre_magi_multicast_chance": {
-    "dname": "+{s:bonus_multicast_2_times}% Multicast Chance"
+    "dname": "+10% Multicast Chance"
   },
   "special_bonus_unique_silencer": {
     "dname": "+{s:bonus_penalty_multiplier} Arcane Curse Silenced Multiplier"
@@ -77729,19 +78022,19 @@
     "dname": "Global Silence Undispellable"
   },
   "special_bonus_unique_silencer_3": {
-    "dname": "+{s:bonus_intellect_damage_pct}% Glaives of Wisdom Damage"
+    "dname": "+30% Glaives of Wisdom Damage"
   },
   "special_bonus_unique_silencer_4": {
-    "dname": "{s:bonus_radius} AoE Last Word"
+    "dname": "250 AoE Last Word"
   },
   "special_bonus_unique_silencer_5": {
-    "dname": "+{s:bonus_int_steal_duration}s Glaives of Wisdom Int Steal Duration"
+    "dname": "+40s Glaives of Wisdom Int Steal Duration"
   },
   "special_bonus_unique_silencer_6": {
     "dname": "+{s:value}% Arcane Curse Slow"
   },
   "special_bonus_unique_silencer_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Global Silence Cooldown"
+    "dname": "-15s Global Silence Cooldown"
   },
   "special_bonus_unique_silencer_arcane_curse_undispellable": {
     "dname": "Arcane Curse Undispellable"
@@ -77756,22 +78049,22 @@
     "dname": "Glaives of Wisdom Pure Damage and Pierce Debuff Immunity"
   },
   "special_bonus_unique_silencer_brain_drain_damage": {
-    "dname": "+{s:bonus_damage_pct}% Suffer In Silence Silenced Target Damage"
+    "dname": "+7% Suffer In Silence Silenced Target Damage"
   },
   "special_bonus_unique_death_prophet": {
-    "dname": "+{s:bonus_spirits} Exorcism Spirits"
+    "dname": "+6 Exorcism Spirits"
   },
   "special_bonus_unique_death_prophet_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Crypt Swarm Cooldown"
+    "dname": "-2.5s Crypt Swarm Cooldown"
   },
   "special_bonus_unique_death_prophet_3": {
-    "dname": "+{s:bonus_damage} Spirit Siphon Damage/Heal"
+    "dname": "+30 Spirit Siphon Damage/Heal"
   },
   "special_bonus_unique_death_prophet_4": {
     "dname": "+{s:bonus_max_moveslow}% Spirit Siphon Max Move Speed Slow"
   },
   "special_bonus_unique_death_prophet_5": {
-    "dname": "-{s:bonus_AbilityChargeRestoreTime}s Spirit Siphon Replenish Time"
+    "dname": "-22s Spirit Siphon Replenish Time"
   },
   "special_bonus_unique_death_prophet_crypt_swarm_slow": {
     "dname": "Crypt Swarm applies {s:bonus_slow_percent}% slow for {s:bonus_slow_duration}s"
@@ -77780,37 +78073,37 @@
     "dname": "-{s:bonus_movement_slow}% Silence Move Speed Slow"
   },
   "special_bonus_unique_death_prophet_crypt_swarm_damage": {
-    "dname": "+{s:bonus_damage} Crypt Swarm Damage"
+    "dname": "+50 Crypt Swarm Damage"
   },
   "special_bonus_unique_death_prophet_silence_aoe": {
-    "dname": "+{s:bonus_radius} Silence AoE"
+    "dname": "+75 Silence AoE"
   },
   "special_bonus_unique_death_prophet_exorcism_duration_on_kill": {
-    "dname": "Deaths During Exorcism Extend Duration By +{s:bonus_duration_increase_per_kill}s"
+    "dname": "Deaths During Exorcism Extend Duration By +8s"
   },
   "special_bonus_unique_phantom_assassin": {
     "dname": "Triple Strike Stifling Dagger"
   },
   "special_bonus_unique_phantom_assassin_2": {
-    "dname": "+{s:bonus_crit_chance}% Coup de Grace chance"
+    "dname": "+10% Coup de Grace chance"
   },
   "special_bonus_unique_phantom_assassin_2_facet_phantom_assassin_methodical": {
     "dname": "-{s:bonus_attacks_to_proc} Attacks to Trigger Coup de Grace"
   },
   "special_bonus_unique_phantom_assassin_3": {
-    "dname": "+{s:bonus_evasion}% Immaterial Evasion"
+    "dname": "+20% Immaterial Evasion"
   },
   "special_bonus_unique_phantom_assassin_4": {
-    "dname": "+{s:bonus_duration}s Phantom Strike Duration"
+    "dname": "+0.8s Phantom Strike Duration"
   },
   "special_bonus_unique_phantom_assassin_5": {
-    "dname": "+{s:bonus_attack_factor}% Stifling Dagger Damage"
+    "dname": "+15% Stifling Dagger Damage"
   },
   "special_bonus_unique_phantom_assassin_6": {
-    "dname": "+{s:bonus_AbilityCastRange} Phantom Strike Cast Range"
+    "dname": "+200 Phantom Strike Cast Range"
   },
   "special_bonus_unique_phantom_assassin_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Stifling Dagger Cooldown"
+    "dname": "-2.0s Stifling Dagger Cooldown"
   },
   "special_bonus_unique_phantom_assassin_8": {
     "dname": "+{s:value} Range and Ground Target Stifling Dagger"
@@ -77819,85 +78112,85 @@
     "dname": "{s:value} Phantom Strike Charges"
   },
   "special_bonus_unique_phantom_assassin_strike_aspd": {
-    "dname": "+{s:bonus_bonus_attack_speed} Phantom Strike Attack Speed"
+    "dname": "+60 Phantom Strike Attack Speed"
   },
   "special_bonus_unique_riki_1": {
-    "dname": "+{s:bonus_damage_multiplier} Backstab Multiplier"
+    "dname": "+0.3 Backstab Multiplier"
   },
   "special_bonus_unique_riki_2": {
     "dname": "+{s:bonus_agility_pct} Tricks of the Trade Agility Increase"
   },
   "special_bonus_unique_riki_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Smoke Screen Cooldown"
+    "dname": "-3s Smoke Screen Cooldown"
   },
   "special_bonus_unique_riki_4": {
     "dname": "+{s:value} Tricks of the Trade Radius"
   },
   "special_bonus_unique_riki_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Blink Strike Cooldown"
+    "dname": "-1s Blink Strike Cooldown"
   },
   "special_bonus_unique_riki_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Tricks of the Trade Cooldown"
+    "dname": "-4s Tricks of the Trade Cooldown"
   },
   "special_bonus_unique_riki_7": {
-    "dname": "+{s:bonus_radius} Smoke Screen Radius"
+    "dname": "+50 Smoke Screen Radius"
   },
   "special_bonus_unique_riki_8": {
-    "dname": "+{s:bonus_invis_movespeed_bonus_percent}% Cloak and Dagger Movement Speed"
+    "dname": "+10% Cloak and Dagger Movement Speed"
   },
   "special_bonus_unique_riki_9": {
-    "dname": "+{s:bonus_AbilityCastRange} Blink Strike Cast Range"
+    "dname": "+500 Blink Strike Cast Range"
   },
   "special_bonus_unique_riki_tricks_dmg": {
-    "dname": "{s:bonus_base_attack_damage_pct}% of Riki's Base damage added to Tricks of the Trade"
+    "dname": "15% of Riki's Base damage added to Tricks of the Trade"
   },
   "special_bonus_unique_tusk": {
-    "dname": "+{s:bonus_crit_multiplier}% Walrus Punch Crit"
+    "dname": "+75% Walrus Punch Crit"
   },
   "special_bonus_unique_tusk_2": {
-    "dname": "+{s:bonus_snowball_damage} Snowball Damage"
+    "dname": "+120 Snowball Damage"
   },
   "special_bonus_unique_tusk_3": {
-    "dname": "+{s:bonus_debuff_duration}s Tag Team Duration"
+    "dname": "+2s Tag Team Duration"
   },
   "special_bonus_unique_tusk_3_facet_tusk_facet_fist_bump": {
     "dname": "+{s:bonus_buff_duration}s Drinking Buddies Duration"
   },
   "special_bonus_unique_tusk_4": {
-    "dname": "{s:bonus_proc_chance}% Chance Walrus Punch"
+    "dname": "12% Chance Walrus Punch"
   },
   "special_bonus_unique_tusk_5": {
     "dname": "-{s:bonus_AbilityCooldown}s Ice Shards Cooldown"
   },
   "special_bonus_unique_tusk_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Snowball Cooldown"
+    "dname": "-6s Snowball Cooldown"
   },
   "special_bonus_unique_tusk_7": {
-    "dname": "+{s:bonus_air_time}s Walrus Punch Stun Duration"
+    "dname": "+0.75s Walrus Punch Stun Duration"
   },
   "special_bonus_unique_tusk_tag_team_armor_reduction": {
     "dname": "-{s:bonus_armor_reduction} Tag Team Armor Reduction"
   },
   "special_bonus_unique_tusk_shard_dps": {
-    "dname": "Ice Shards slow by {s:bonus_aghs_shard_move_slow}% and deal {s:bonus_aghs_shard_damage} DPS"
+    "dname": "Ice Shards slow by 50% and deal 110 DPS"
   },
   "special_bonus_unique_sniper_1": {
-    "dname": "+{s:bonus_damage} Assassinate Damage"
+    "dname": "+150 Assassinate Damage"
   },
   "special_bonus_unique_sniper_2": {
-    "dname": "-{s:bonus_AbilityChargeRestoreTime}s Shrapnel Charge Restore Time"
+    "dname": "-30s Shrapnel Charge Restore Time"
   },
   "special_bonus_unique_sniper_3": {
-    "dname": "+{s:bonus_knockback_distance} Max Headshot Knockback Distance"
+    "dname": "+50 Max Headshot Knockback Distance"
   },
   "special_bonus_unique_sniper_4": {
-    "dname": "+{s:bonus_duration}s Take Aim Duration"
+    "dname": "+2s Take Aim Duration"
   },
   "special_bonus_unique_sniper_5": {
-    "dname": "+{s:bonus_passive_attack_range_bonus} Take Aim Passive Attack Range"
+    "dname": "+50 Take Aim Passive Attack Range"
   },
   "special_bonus_unique_sniper_6": {
-    "dname": "+{s:bonus_attack_speed} Attack Speed During Take Aim"
+    "dname": "+45 Attack Speed During Take Aim"
   },
   "special_bonus_unique_sniper_take_aim_armor": {
     "dname": "+{s:bonus_bonus_armor} Take Aim Armor"
@@ -77909,13 +78202,13 @@
     "dname": "Concussive Grenade Pushes Sniper back"
   },
   "special_bonus_unique_sniper_headshot_damage": {
-    "dname": "+{s:bonus_damage} Headshot Damage"
+    "dname": "+30 Headshot Damage"
   },
   "special_bonus_unique_sniper_shrapnel_damage": {
     "dname": "+{s:bonus_shrapnel_damage}% Shrapnel Damage"
   },
   "special_bonus_unique_magnus": {
-    "dname": "+{s:bonus_shock_damage} Shockwave Damage"
+    "dname": "+125 Shockwave Damage"
   },
   "special_bonus_unique_magnus_2": {
     "dname": "Shockwave Returns to Magnus"
@@ -77924,109 +78217,109 @@
     "dname": "+{s:bonus_range} Skewer Range"
   },
   "special_bonus_unique_magnus_4": {
-    "dname": "+{s:bonus_empower_duration}s Empower Duration"
+    "dname": "+10s Empower Duration"
   },
   "special_bonus_unique_magnus_5": {
-    "dname": "+{s:bonus_hero_stun_duration}s Reverse Polarity Stun Duration"
+    "dname": "+0.8s Reverse Polarity Stun Duration"
   },
   "special_bonus_unique_magnus_6": {
-    "dname": "+{s:bonus_slow_duration}s Skewer Slow Duration"
+    "dname": "+1.25s Skewer Slow Duration"
   },
   "special_bonus_unique_magnus_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Skewer Cooldown"
+    "dname": "-5s Skewer Cooldown"
   },
   "special_bonus_unique_magnus_reverse_polarity_stats": {
-    "dname": "+{s:bonus_stats_per_stack} All Attributes per hero hit with Reverse Polarity"
+    "dname": "+14 All Attributes per hero hit with Reverse Polarity"
   },
   "special_bonus_unique_magnus_skewer_damage_distance": {
-    "dname": "+{s:bonus_damage_distance_pct}% Skewer Damage Per Distance Travelled"
+    "dname": "+15% Skewer Damage Per Distance Travelled"
   },
   "special_bonus_unique_earth_spirit_rolling_boulder_cooldown": {
     "dname": "-{s:bonus_AbilityCooldown} Rolling Boulder Cooldown"
   },
   "special_bonus_unique_earth_spirit_rolling_boulder_stun": {
-    "dname": "+{s:bonus_stun_duration}s Rolling Boulder Stun Duration"
+    "dname": "+0.3s Rolling Boulder Stun Duration"
   },
   "special_bonus_unique_huskar": {
-    "dname": "+{s:bonus_tooltip_health_damage}% Life Break Damage"
+    "dname": "+22% Life Break Damage"
   },
   "special_bonus_unique_huskar_2": {
-    "dname": "+{s:bonus_burn_damage} Burning Spear Burn Damage"
+    "dname": "+5 Burning Spear Burn Damage"
   },
   "special_bonus_unique_huskar_3": {
-    "dname": "+{s:bonus_disarm_duration}s Inner Fire Duration"
+    "dname": "+0.75s Inner Fire Duration"
   },
   "special_bonus_unique_huskar_4": {
-    "dname": "+{s:bonus_slow_duration_tooltip}s Life Break Slow Duration"
+    "dname": "+2s Life Break Slow Duration"
   },
   "special_bonus_unique_huskar_5": {
-    "dname": "+{s:bonus_duration}s Burning Spear Duration"
+    "dname": "+6s Burning Spear Duration"
   },
   "special_bonus_unique_huskar_6": {
-    "dname": "+{s:bonus_maximum_health_regen}% Berserker's Blood Regen"
+    "dname": "+30% Berserker's Blood Regen"
   },
   "special_bonus_unique_huskar_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Life Break Cooldown"
+    "dname": "-5s Life Break Cooldown"
   },
   "special_bonus_unique_naga_siren": {
-    "dname": "+{s:bonus_images_count} Mirror Image Illusion"
+    "dname": "+1 Mirror Image Illusion"
   },
   "special_bonus_unique_naga_siren_2": {
-    "dname": "+{s:bonus_damage}% Rip Tide Damage"
+    "dname": "+30% Rip Tide Damage"
   },
   "special_bonus_unique_naga_siren_2_facet_naga_siren_active_riptide": {
     "dname": "+{s:bonus_damage}% Deluge Damage"
   },
   "special_bonus_unique_naga_siren_3": {
-    "dname": "-{s:bonus_incoming_damage}% Mirror Image Illusion Damage Taken"
+    "dname": "-75% Mirror Image Illusion Damage Taken"
   },
   "special_bonus_unique_naga_siren_4": {
-    "dname": "+{s:bonus_outgoing_damage_tooltip}% Mirror Image Damage"
+    "dname": "+10% Mirror Image Damage"
   },
   "special_bonus_unique_naga_siren_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Song of the Siren Cooldown"
+    "dname": "-25s Song of the Siren Cooldown"
   },
   "special_bonus_unique_naga_siren_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Mirror Image Cooldown"
+    "dname": "-10s Mirror Image Cooldown"
   },
   "special_bonus_unique_naga_siren_7": {
     "dname": "Song of the Siren heals allies {s:value}% Max HP/s"
   },
   "special_bonus_unique_naga_siren_net_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Ensnare Cooldown"
+    "dname": "-2s Ensnare Cooldown"
   },
   "special_bonus_unique_naga_siren_net_breaks": {
     "dname": "Ensnare applies Break"
   },
   "special_bonus_unique_naga_siren_reel_in_speed": {
-    "dname": "+{s:bonus_pull_strength} Reel In Pull Speed"
+    "dname": "+125 Reel In Pull Speed"
   },
   "special_bonus_unique_oracle": {
-    "dname": "+{s:bonus_duration}s False Promise Duration"
+    "dname": "+1.5s False Promise Duration"
   },
   "special_bonus_unique_oracle_2": {
-    "dname": "+{s:bonus_maximum_purge_duration}s Fortune's End Duration"
+    "dname": "+0.5s Fortune's End Duration"
   },
   "special_bonus_unique_oracle_3": {
-    "dname": "+{s:bonus_radius} Fortune's End Radius"
+    "dname": "+100 Fortune's End Radius"
   },
   "special_bonus_unique_oracle_4": {
     "dname": "False Promise Invisibility"
   },
   "special_bonus_unique_oracle_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Purifying Flames Cooldown"
+    "dname": "-1s Purifying Flames Cooldown"
   },
   "special_bonus_unique_oracle_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s False Promise Cooldown"
+    "dname": "-20s False Promise Cooldown"
   },
   "special_bonus_unique_oracle_7": {
     "dname": "Fortune's End constantly Dispels"
   },
   "special_bonus_unique_oracle_8": {
-    "dname": "+{s:bonus_damage_modifier}% Purifying Flames Enemy Damage"
+    "dname": "+25% Purifying Flames Enemy Damage"
   },
   "special_bonus_unique_oracle_9": {
-    "dname": "+{s:bonus_bonus_armor} Armor False Promise"
+    "dname": "+8 Armor False Promise"
   },
   "special_bonus_unique_oracle_fortunes_end_damage": {
     "dname": "+{s:bonus_damage} Fortune's End Damage"
@@ -78035,16 +78328,16 @@
     "dname": "Fortune's End Heals/Damages for {s:bonus_damage_per_buff} Per Effect Dispelled"
   },
   "special_bonus_unique_sand_king": {
-    "dname": "+{s:bonus_epicenter_pulses} Epicenter Pulses"
+    "dname": "+6 Epicenter Pulses"
   },
   "special_bonus_unique_sand_king_2": {
-    "dname": "+{s:bonus_sand_storm_damage} Sand Storm Damage Per Second"
+    "dname": "+25 Sand Storm Damage Per Second"
   },
   "special_bonus_unique_sand_king_3": {
-    "dname": "+{s:bonus_strike_slow}% Stinger Slow"
+    "dname": "+12% Stinger Slow"
   },
   "special_bonus_unique_sand_king_4": {
-    "dname": "{s:bonus_sand_storm_slow}% Sand Storm Slow and Blind"
+    "dname": "35% Sand Storm Slow and Blind"
   },
   "special_bonus_unique_sand_king_5": {
     "dname": "+{s:bonus_epicenter_radius_base}/{s:bonus_epicenter_radius_increment} Base/Incremental Radius of Epicenter"
@@ -78053,34 +78346,34 @@
     "dname": "+{s:value}% Caustic Finale Slow"
   },
   "special_bonus_unique_sand_king_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Burrowstrike Cooldown"
+    "dname": "-3s Burrowstrike Cooldown"
   },
   "special_bonus_unique_sand_king_8": {
-    "dname": "+{s:bonus_AbilityCastRange} Burrowstrike Cast Range"
+    "dname": "+200 Burrowstrike Cast Range"
   },
   "special_bonus_unique_sand_king_burrowstrike_stun": {
     "dname": "+{s:bonus_burrow_duration}s Burrowstrike Stun"
   },
   "special_bonus_unique_sand_king_scorpion_strike_damage": {
-    "dname": "+{s:bonus_attack_damage} Stinger Damage"
+    "dname": "+125 Stinger Damage"
   },
   "special_bonus_unique_sand_king_caustic_finale_radius": {
-    "dname": "+{s:bonus_caustic_finale_radius} Caustic Finale Radius"
+    "dname": "+100 Caustic Finale Radius"
   },
   "special_bonus_unique_sand_king_epicenter_passive_proc": {
     "dname": "Create {s:bonus_shard_radius} AoE Epicenter Pulse around Sand King every 3s"
   },
   "special_bonus_unique_shadow_demon_1": {
-    "dname": "+{s:bonus_purge_damage} Demonic Purge Damage"
+    "dname": "+150 Demonic Purge Damage"
   },
   "special_bonus_unique_shadow_demon_2": {
     "dname": "-{s:value}s Soul Catcher Cooldown"
   },
   "special_bonus_unique_shadow_demon_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Shadow Poison Cooldown"
+    "dname": "-1s Shadow Poison Cooldown"
   },
   "special_bonus_unique_shadow_demon_4": {
-    "dname": "+{s:bonus_stack_damage}% Shadow Poison Damage"
+    "dname": "+15% Shadow Poison Damage"
   },
   "special_bonus_unique_shadow_demon_5": {
     "dname": "+{s:bonus_disruption_duration}s Disruption Banish Duration"
@@ -78089,16 +78382,16 @@
     "dname": "Soul Catcher Creates 2 Illusion On Death"
   },
   "special_bonus_unique_shadow_demon_7": {
-    "dname": "{s:bonus_AbilityCharges} Charges of Disruption"
+    "dname": "2 Charges of Disruption"
   },
   "special_bonus_unique_shadow_demon_8": {
     "dname": "+{s:value}s Soul Catcher Duration"
   },
   "special_bonus_unique_shadow_demon_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Demonic Purge Cooldown"
+    "dname": "-20s Demonic Purge Cooldown"
   },
   "special_bonus_unique_shadow_demon_disseminate_damage": {
-    "dname": "+{s:bonus_damage_reflection_pct}% Disseminate Shared Damage"
+    "dname": "+15% Disseminate Shared Damage"
   },
   "special_bonus_unique_shadow_demon_purge_poison": {
     "dname": "Demonic Purge Applies Shadow Poison"
@@ -78113,31 +78406,31 @@
     "dname": "Gust Reveals Invisible Units"
   },
   "special_bonus_unique_slardar": {
-    "dname": "+{s:bonus_crush_damage} Slithereen Crush Damage"
+    "dname": "+125 Slithereen Crush Damage"
   },
   "special_bonus_unique_slardar_2": {
-    "dname": "+{s:bonus_bonus_damage} Bash of the Deep Damage"
+    "dname": "+30 Bash of the Deep Damage"
   },
   "special_bonus_unique_slardar_3": {
     "dname": "Corrosive Haze Undispellable"
   },
   "special_bonus_unique_slardar_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Slithereen Crush Cooldown"
+    "dname": "-3s Slithereen Crush Cooldown"
   },
   "special_bonus_unique_slardar_5": {
-    "dname": "-{s:bonus_armor_reduction} Corrosive Haze Armor"
+    "dname": "-3 Corrosive Haze Armor"
   },
   "special_bonus_unique_slardar_6": {
-    "dname": "+{s:bonus_river_damage_pct}% Seaborn Sentinel Bonus Attack Damage"
+    "dname": "+16% Seaborn Sentinel Bonus Attack Damage"
   },
   "special_bonus_unique_slardar_7": {
-    "dname": "+{s:bonus_duration}s Guardian Sprint Duration"
+    "dname": "+2s Guardian Sprint Duration"
   },
   "special_bonus_unique_slardar_8": {
     "dname": "+{s:value}% Slithereen Crush Attack/Move Slow"
   },
   "special_bonus_unique_slardar_slithereen_crush_stun": {
-    "dname": "+{s:bonus_stun_duration}s Slithereen Crush Stun Duration"
+    "dname": "+0.2s Slithereen Crush Stun Duration"
   },
   "special_bonus_unique_lina_5": {
     "dname": "+{s:bonus_damage} Laguna Blade Damage"
@@ -78155,7 +78448,7 @@
     "dname": "+{s:bonus_movement_speed_pct}% Ice Vortex Slow/Increased Magic Damage"
   },
   "special_bonus_unique_ancient_apparition_cold_feet_distance": {
-    "dname": "+{s:bonus_break_distance} Cold Feet Break Distance"
+    "dname": "+250 Cold Feet Break Distance"
   },
   "special_bonus_unique_disruptor_2_Facet_disruptor_line_walls": {
     "dname": "+{s:bonus_AbilityChargeRestoreTime}s Kinetic Fence Charge Restore Time"
@@ -78173,52 +78466,52 @@
     "dname": "Kinetic Fields Independent Cooldown"
   },
   "special_bonus_unique_disruptor_kinetic_damage": {
-    "dname": "+{s:bonus_damage_per_second} Kinetic Field Touch DPS"
+    "dname": "+60 Kinetic Field Touch DPS"
   },
   "special_bonus_unique_disruptor_thunder_strike_strikes": {
-    "dname": "+{s:bonus_strikes} Thunder Strike Strikes"
+    "dname": "+6 Thunder Strike Strikes"
   },
   "special_bonus_unique_gyrocopter_1": {
-    "dname": "-{s:bonus_AbilityCooldown}s Flak Cannon Cooldown"
+    "dname": "-6s Flak Cannon Cooldown"
   },
   "special_bonus_unique_gyrocopter_2": {
-    "dname": "+{s:bonus_max_attacks} Flak Cannon Attacks"
+    "dname": "+3 Flak Cannon Attacks"
   },
   "special_bonus_unique_gyrocopter_3": {
-    "dname": "+{s:bonus_rocket_damage} Rocket Barrage Damage"
+    "dname": "+14 Rocket Barrage Damage"
   },
   "special_bonus_unique_gyrocopter_4": {
     "dname": "+{s:bonus_bonus_movement_speed} Movement Speed during Rocket Barrage"
   },
   "special_bonus_unique_gyrocopter_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Call Down Cooldown"
+    "dname": "-40s Call Down Cooldown"
   },
   "special_bonus_unique_gyrocopter_6": {
-    "dname": "+{s:bonus_stun_duration}s Homing Missile Stun Duration"
+    "dname": "+0.3s Homing Missile Stun Duration"
   },
   "special_bonus_unique_gyrocopter_flak_cannon_bonus_damage": {
-    "dname": "+{s:bonus_bonus_damage} Flak Cannon Damage"
+    "dname": "+25 Flak Cannon Damage"
   },
   "special_bonus_unique_gyrocopter_homing_missile_damage": {
-    "dname": "+{s:bonus_hit_damage}% Homing Missile Damage"
+    "dname": "+25% Homing Missile Damage"
   },
   "special_bonus_unique_gyrocopter_flak_cannon_range": {
     "dname": "+{s:bonus_radius} Flak Cannon Attack Radius"
   },
   "special_bonus_unique_keeper_of_the_light": {
-    "dname": "+{s:bonus_total_damage} Illuminate Damage"
+    "dname": "+200 Illuminate Damage"
   },
   "special_bonus_unique_keeper_of_the_light_2": {
-    "dname": "+{s:bonus_duration}s Spirit Form Duration"
+    "dname": "+15s Spirit Form Duration"
   },
   "special_bonus_unique_keeper_of_the_light_3": {
-    "dname": "+{s:bonus_magic_resistance}% Solar Bind Magic Resistance Reduction"
+    "dname": "+10% Solar Bind Magic Resistance Reduction"
   },
   "special_bonus_unique_keeper_of_the_light_4": {
     "dname": "+{s:value} Will-O-Wisp Health Count"
   },
   "special_bonus_unique_keeper_of_the_light_5": {
-    "dname": "+{s:bonus_damage} Blinding Light Damage"
+    "dname": "+90 Blinding Light Damage"
   },
   "special_bonus_unique_keeper_of_the_light_6": {
     "dname": "+{s:value} Will-O-Wisp AoE"
@@ -78227,7 +78520,7 @@
     "dname": "-{s:bonus_AbilityCooldown}s Chakra Magic Cooldown"
   },
   "special_bonus_unique_keeper_of_the_light_8": {
-    "dname": "+{s:bonus_miss_rate}% Blinding Light Miss"
+    "dname": "+40% Blinding Light Miss"
   },
   "special_bonus_unique_keeper_of_the_light_9": {
     "dname": "+{s:value}% Illuminate Daytime Heal"
@@ -78239,7 +78532,7 @@
     "dname": "-{s:bonus_teleport_delay}s Recall Teleport Delay"
   },
   "special_bonus_unique_keeper_of_the_light_11": {
-    "dname": "+{s:bonus_movement_speed}% Spirit Form Bright Speed Bonus"
+    "dname": "+25% Spirit Form Bright Speed Bonus"
   },
   "special_bonus_unique_keeper_of_the_light_12": {
     "dname": "{s:value} Blinding Light Charges"
@@ -78254,7 +78547,7 @@
     "dname": "Chakra Magic Strong Dispels"
   },
   "special_bonus_unique_keeper_of_the_light_illuminate_cooldown": {
-    "dname": "-{s:bonus_AbilityCooldown}s Illuminate Cooldown"
+    "dname": "-2s Illuminate Cooldown"
   },
   "special_bonus_unique_legion_commander": {
     "dname": "+{s:value} Duel Bonus Damage"
@@ -78263,43 +78556,43 @@
     "dname": "+{s:bonus_radius} Overwhelming Odds Radius"
   },
   "special_bonus_unique_legion_commander_3": {
-    "dname": "-{s:bonus_trigger_attacks} Moment of Courage Attacks To Trigger"
+    "dname": "-1 Moment of Courage Attacks To Trigger"
   },
   "special_bonus_unique_legion_commander_4": {
-    "dname": "+{s:bonus_damage_per_hero} Overwhelming Odds Damage per Hero"
+    "dname": "+35 Overwhelming Odds Damage per Hero"
   },
   "special_bonus_unique_legion_commander_5": {
     "dname": "{s:bonus_radius} AoE Press The Attack"
   },
   "special_bonus_unique_legion_commander_6": {
-    "dname": "+{s:bonus_hp_regen} Press The Attack HP Regen"
+    "dname": "+40 Press The Attack HP Regen"
   },
   "special_bonus_unique_legion_commander_7": {
-    "dname": "+{s:bonus_hp_leech_percent}% Moment of Courage Lifesteal"
+    "dname": "+100% Moment of Courage Lifesteal"
   },
   "special_bonus_unique_legion_commander_8": {
-    "dname": "Press the Attack grants {s:bonus_immunity_duration}s Debuff Immunity"
+    "dname": "Press the Attack grants 1.5s Debuff Immunity"
   },
   "special_bonus_unique_legion_commander_9": {
-    "dname": "-{s:bonus_AbilityCooldown}s Overwhelming Odds Cooldown"
+    "dname": "-2s Overwhelming Odds Cooldown"
   },
   "special_bonus_unique_legion_commander_pta_movespeed": {
     "dname": "+{s:bonus_move_speed}% Press The Attack Movement Speed"
   },
   "special_bonus_unique_legion_commander_duel_duration": {
-    "dname": "+{s:bonus_duration}s Duel Duration"
+    "dname": "+0.75s Duel Duration"
   },
   "special_bonus_unique_legion_commander_duel_refresh_on_victory": {
     "dname": "Duel Refreshes Cooldown On Victory"
   },
   "special_bonus_unique_legion_commander_outfight_them_armor": {
-    "dname": "+{s:bonus_armor} Outfight Them! Armor"
+    "dname": "+1 Outfight Them! Armor"
   },
   "special_bonus_unique_puck": {
-    "dname": "-{s:bonus_AbilityCooldown}s Dream Coil Cooldown"
+    "dname": "-30s Dream Coil Cooldown"
   },
   "special_bonus_unique_puck_2": {
-    "dname": "-{s:bonus_AbilityCooldown}s Waning Rift Cooldown"
+    "dname": "-2.5s Waning Rift Cooldown"
   },
   "special_bonus_unique_puck_3": {
     "dname": "Dream Coil Rapid Fire"
@@ -78308,82 +78601,82 @@
     "dname": "+{s:bonus_coil_stun_duration}s Dream Coil Stun Duration"
   },
   "special_bonus_unique_puck_5": {
-    "dname": "Dream Coil Pierces Debuff Immunity"
+    "dname": "+2% Puckish Health and Mana Restoration"
   },
   "special_bonus_unique_puck_6": {
-    "dname": "+{s:bonus_damage} Waning Rift Damage"
+    "dname": "+60 Waning Rift Damage"
   },
   "special_bonus_unique_puck_7": {
-    "dname": "+{s:bonus_silence_duration}s Waning Rift Silence Duration"
+    "dname": "+1.25s Waning Rift Silence Duration"
   },
   "special_bonus_unique_puck_8": {
     "dname": "-{s:bonus_AbilityCooldown}s Illusory Orb Cooldown"
   },
   "special_bonus_unique_puck_orb_damage": {
-    "dname": "+{s:bonus_damage} Illusory Orb Damage"
+    "dname": "+35 Illusory Orb Damage"
   },
   "special_bonus_unique_puck_coil_damage": {
-    "dname": "+{s:bonus_coil_break_damage} Initial/Break Dream Coil Damage"
+    "dname": "+200 Initial/Break Dream Coil Damage"
   },
   "special_bonus_unique_puck_rift_radius": {
-    "dname": "+{s:bonus_radius} Waning Rift Radius/Max Distance"
+    "dname": "+350 Waning Rift Radius/Max Distance"
   },
   "special_bonus_unique_pugna_1": {
-    "dname": "+{s:bonus_bonus_heal_pct}% Life Drain Heal"
+    "dname": "+15% Life Drain Heal"
   },
   "special_bonus_unique_pugna_2": {
-    "dname": "+{s:bonus_blast_damage} Nether Blast Damage"
+    "dname": "+200 Nether Blast Damage"
   },
   "special_bonus_unique_pugna_3": {
-    "dname": "+{s:bonus_mana_multiplier} Nether Ward Damage Per Mana"
+    "dname": "+1.9 Nether Ward Damage Per Mana"
   },
   "special_bonus_unique_pugna_4": {
-    "dname": "-{s:bonus_AbilityCooldown}s Nether Blast Cooldown"
+    "dname": "-1s Nether Blast Cooldown"
   },
   "special_bonus_unique_pugna_5": {
-    "dname": "+{s:bonus_AbilityDuration}s Decrepify Duration"
+    "dname": "+1.5s Decrepify Duration"
   },
   "special_bonus_unique_pugna_6": {
-    "dname": "+{s:bonus_attacks_to_destroy} Nether Ward Health"
+    "dname": "+2 Nether Ward Health"
   },
   "special_bonus_unique_pugna_decrepify_ally_movespeed": {
-    "dname": "+{s:bonus_bonus_movement_speed_allies}% Decrepify Movement Speed To Allies"
+    "dname": "+30% Decrepify Movement Speed To Allies"
   },
   "special_bonus_unique_timbersaw": {
-    "dname": "+{s:bonus_tree_damage_scale} Whirling Death Tree Bonus Damage"
+    "dname": "+75 Whirling Death Tree Bonus Damage"
   },
   "special_bonus_unique_timbersaw_2": {
-    "dname": "+{s:bonus_stack_limit} Max / +{s:bonus_stacks_per_hero_attack} Hero Attack Reactive Armor Stacks"
+    "dname": "+6 Max / +1 Hero Attack Reactive Armor Stacks"
   },
   "special_bonus_unique_timbersaw_3": {
-    "dname": "+{s:bonus_AbilityCastRange}% Timber Chain Range/Projectile Speed"
+    "dname": "+75% Timber Chain Range/Projectile Speed"
   },
   "special_bonus_unique_timbersaw_4": {
-    "dname": "+{s:bonus_slow}% Chakram Slow"
+    "dname": "+6% Chakram Slow"
   },
   "special_bonus_unique_timbersaw_5": {
-    "dname": "+{s:bonus_stat_loss_pct}% Whirling Death Stat Loss"
+    "dname": "+2% Whirling Death Stat Loss"
   },
   "special_bonus_unique_timbersaw_reactive_armor_regen_per_stack": {
-    "dname": "+{s:bonus_bonus_hp_regen} Reactive Armor Regeneration Per Stack"
+    "dname": "+0.25 Reactive Armor Regeneration Per Stack"
   },
   "special_bonus_unique_timbersaw_exposure_therapy_health": {
-    "dname": "Exposure Therapy Heals for {s:bonus_health_restore} HP Per Tree Destroyed"
+    "dname": "Exposure Therapy Heals for 12 HP Per Tree Destroyed"
   },
   "special_bonus_unique_bloodseeker": {
-    "dname": "-{s:bonus_damage_pct}% Bloodrage Max Health DPS"
+    "dname": "-0.7% Bloodrage Max Health DPS"
   },
   "special_bonus_unique_bloodseeker_2": {
-    "dname": "+{s:bonus_damage} Blood Rite Damage"
+    "dname": "+100 Blood Rite Damage"
   },
   "special_bonus_unique_bloodseeker_3": {
-    "dname": "+{s:bonus_AbilityCastRange} Rupture Cast Range"
+    "dname": "+400 Rupture Cast Range"
   },
   "special_bonus_unique_bloodseeker_4": {
-    "dname": "+{s:bonus_bonus_movement_speed}% Max Thirst MS"
+    "dname": "+15% Max Thirst Move Speed"
   },
   "special_bonus_unique_bloodseeker_5": {
-    "dname": "+{s:bonus_attack_speed} Bloodrage Attack Speed"
+    "dname": "+30 Bloodrage Attack Speed"
   },
   "special_bonus_unique_bloodseeker_6": {
     "dname": "{s:bonus_spell_amp}% Bloodrage Spell Amplification"
@@ -78392,61 +78685,61 @@
     "dname": "+{s:bonus_base_damage_amp}% Bloodrage Base Damage Amp"
   },
   "special_bonus_unique_bloodseeker_overheal_barrier": {
-    "dname": "Overheal grants All Damage Barrier up to {s:bonus_max_shield_pct}% Max Health"
+    "dname": "Overheal grants All Damage Barrier up to 35% Max Health"
   },
   "special_bonus_unique_bloodseeker_pure_damage_lifesteal": {
-    "dname": "+{s:bonus_pure_damage_lifesteal_pct}% Pure Damage Lifesteal"
+    "dname": "+=25% Pure Damage Lifesteal"
   },
   "special_bonus_unique_bloodseeker_7": {
-    "dname": "+{s:bonus_silence_duration}s Blood Rite Silence Duration"
+    "dname": "+3.0s Blood Rite Silence Duration"
   },
   "special_bonus_unique_bloodseeker_rupture_charges": {
     "dname": "{s:bonus_AbilityCharges} Rupture Charges"
   },
   "special_bonus_unique_outworld_devourer": {
-    "dname": "+{s:bonus_mana_pool_damage_pct}% Arcane Orb Damage"
+    "dname": "+1.5% Arcane Orb Damage"
   },
   "special_bonus_unique_outworld_devourer_4": {
-    "dname": "+{s:bonus_mana_capacity_steal}% Astral Imprisonment Mana Capacity Steal"
+    "dname": "+12% Astral Imprisonment Mana Capacity Steal"
   },
   "special_bonus_unique_outworld_devourer_3": {
-    "dname": "+{s:bonus_mana_as_ms}% of Current Mana as Movement Speed"
+    "dname": "+=0.8% of Current Mana as Movement Speed"
   },
   "special_bonus_unique_outworld_devourer_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Sanity's Eclipse Cooldown"
+    "dname": "-60s Sanity's Eclipse Cooldown"
   },
   "special_bonus_unique_outworld_devourer_astral_castrange": {
-    "dname": "+{s:bonus_AbilityCastRange} Astral Imprisonment Cast Range"
+    "dname": "+100 Astral Imprisonment Cast Range"
   },
   "special_bonus_unique_outworld_devourer_barrier": {
-    "dname": "-{s:bonus_AbilityCooldown}s Objurgation Cooldown"
+    "dname": "-10s Objurgation Cooldown"
   },
   "special_bonus_unique_outworld_devourer_prison_duration": {
     "dname": "+{s:bonus_prison_duration}s Astral Imprisonment Prison"
   },
   "special_bonus_unique_outworld_devourer_flux_restore": {
-    "dname": "+{s:bonus_mana_restore}% Essence Flux Mana Restored"
+    "dname": "+5% Essence Flux Mana Restored"
   },
   "special_bonus_unique_broodmother_1": {
-    "dname": "-{s:bonus_bat_bonus}s BAT during Insatiable Hunger"
+    "dname": "-0.15s BAT during Insatiable Hunger"
   },
   "special_bonus_unique_broodmother_2": {
-    "dname": "+{s:bonus_attack_damage} Incapacitating Bite Attack Bonus"
+    "dname": "+5 Incapacitating Bite Attack Bonus"
   },
   "special_bonus_unique_broodmother_3": {
-    "dname": "+{s:bonus_damage} Spawn Spiderlings Damage"
+    "dname": "+80 Spawn Spiderlings Damage"
   },
   "special_bonus_unique_broodmother_4": {
-    "dname": "+{s:bonus_miss_chance}% Incapacitating Bite Slow/Miss Chance"
+    "dname": "+20% Incapacitating Bite Slow/Miss Chance"
   },
   "special_bonus_unique_broodmother_5": {
-    "dname": "-{s:bonus_AbilityChargeRestoreTime}s Spin Web Charge Restore Time"
+    "dname": "-6s Spin Web Charge Restore Time"
   },
   "special_bonus_unique_broodmother_6": {
-    "dname": "+{s:bonus_lifesteal_pct}% Insatiable Hunger Lifesteal"
+    "dname": "+20% Insatiable Hunger Lifesteal"
   },
   "special_bonus_unique_broodmother_7": {
-    "dname": "+{s:bonus_hp_bonus} Spiderlings Health"
+    "dname": "+175 Spiderlings Health"
   },
   "special_bonus_unique_broodmother_web_hpregen": {
     "dname": "+{s:bonus_health_regen} Spin Web Health Regeneration"
@@ -78464,10 +78757,10 @@
     "dname": "+{s:bonus_attack_speed} Convert Attack Speed"
   },
   "special_bonus_unique_chen_4": {
-    "dname": "+{s:bonus_health_min} Holy Persuasion Minimum Health"
+    "dname": "+1300 Holy Persuasion Minimum Health"
   },
   "special_bonus_unique_chen_5": {
-    "dname": "+{s:bonus_damage_bonus}% Holy Persuasion Damage"
+    "dname": "+12% Holy Persuasion Damage"
   },
   "special_bonus_unique_chen_6": {
     "dname": "-{s:value}s Divine Favor Cooldown"
@@ -78476,7 +78769,7 @@
     "dname": "-{s:value}s Hand of God Cooldown"
   },
   "special_bonus_unique_chen_8": {
-    "dname": "-{s:bonus_bonus_movement_speed}% Penitence Slow"
+    "dname": "+15% Penitence Slow"
   },
   "special_bonus_unique_chen_9": {
     "dname": "Holy Persuasion Targets Ancients"
@@ -78485,16 +78778,16 @@
     "dname": "Global Divine Favor Aura"
   },
   "special_bonus_unique_chen_11": {
-    "dname": "+{s:bonus_damage} Penitence Damage"
+    "dname": "+75 Penitence Damage"
   },
   "special_bonus_unique_chen_12": {
     "dname": "Hand of God applies a Strong Dispel"
   },
   "special_bonus_unique_chen_divine_favor_healing": {
-    "dname": "+{s:bonus_heal_amp}% Divine Favor Heal Amplification"
+    "dname": "+15% Divine Favor Heal Amplification"
   },
   "special_bonus_unique_lone_druid_1": {
-    "dname": "+{s:bonus_damage} Entangle Root Damage Per Second"
+    "dname": "+20 Entangle Root Damage Per Second"
   },
   "special_bonus_unique_lone_druid_3": {
     "dname": "+{s:bonus_bonus_building_damage} Demolish Building Armor Reduction"
@@ -78521,64 +78814,64 @@
     "dname": "+{s:bonus_bonus_attack_speed} Spirit Link Attack Speed"
   },
   "special_bonus_unique_lone_druid_entangle_duration": {
-    "dname": "+{s:bonus_entangle_duration}s Entangle Root Duration"
+    "dname": "+0.6s Entangle Root Duration"
   },
   "special_bonus_unique_wisp": {
-    "dname": "+{s:bonus_hero_damage} Spirits Hero Damage"
+    "dname": "+50% Spirits Damage"
   },
   "special_bonus_unique_wisp_2": {
     "dname": "Tether Stuns"
   },
   "special_bonus_unique_wisp_3": {
-    "dname": "+{s:bonus_movespeed}% Tether Movement Speed"
+    "dname": "+5% Tether Movement Speed"
   },
   "special_bonus_unique_wisp_4": {
-    "dname": "Attack Tethered Ally's Target ({s:bonus_tether_attack_damage_pct}% damage)"
+    "dname": "Attack Tethered Ally's Target (=50% damage)"
   },
   "special_bonus_unique_wisp_5": {
     "dname": "Tether Grants Scepter Bonus"
   },
   "special_bonus_unique_wisp_6": {
-    "dname": "-{s:bonus_AbilityCooldown}s Relocate Cooldown"
+    "dname": "-30s Relocate Cooldown"
   },
   "special_bonus_unique_wisp_7": {
     "dname": "Spirits Apply Slow"
   },
   "special_bonus_unique_wisp_8": {
-    "dname": "Overcharge grants {s:bonus_bonus_attack_speed} Attack Speed"
+    "dname": "Overcharge grants 40 Attack Speed"
   },
   "special_bonus_unique_wisp_9": {
     "dname": "Unslowable during Overcharge"
   },
   "special_bonus_unique_wisp_10": {
-    "dname": "+{s:bonus_hp_regen}% Overcharge Max HP Regen Bonus"
+    "dname": "+0.2% Overcharge Max HP Regen Bonus"
   },
   "special_bonus_unique_wisp_11": {
     "dname": "+{s:bonus_slow}% Tether Enemy Move/Attack Slow"
   },
   "special_bonus_unique_wisp_overcharge_duration": {
-    "dname": "+{s:bonus_duration}s Overcharge Duration"
+    "dname": "+1.5s Overcharge Duration"
   },
   "special_bonus_unique_wisp_relocate_delay": {
-    "dname": "-{s:bonus_cast_delay}s Relocate Cast Delay"
+    "dname": "-2.0s Relocate Cast Delay"
   },
   "special_bonus_unique_techies": {
-    "dname": "+{s:bonus_damage} Blast Off! Damage"
+    "dname": "+175 Blast Off! Damage"
   },
   "special_bonus_unique_techies_2": {
-    "dname": "+{s:bonus_damage} Sticky Bomb Damage"
+    "dname": "+160 Sticky Bomb Damage"
   },
   "special_bonus_unique_techies_3": {
-    "dname": "-{s:bonus_AbilityChargeRestoreTime}s Proximity Mines Cooldown"
+    "dname": "-2s Proximity Mines Cooldown"
   },
   "special_bonus_unique_techies_4": {
-    "dname": "-{s:bonus_activation_delay}s Proximity Mines Activation Delay"
+    "dname": "-0.8s Proximity Mines Activation Delay"
   },
   "special_bonus_unique_techies_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Blast Off! Cooldown"
+    "dname": "-15s Blast Off! Cooldown"
   },
   "special_bonus_unique_techies_tazer_duration": {
-    "dname": "+{s:bonus_duration}% Reactive Tazer Buff and Disarm Duration"
+    "dname": "+25% Reactive Tazer Buff and Disarm Duration"
   },
   "special_bonus_unique_arc_warden_2": {
     "dname": "+{s:bonus_damage_per_second} Flux Damage"
@@ -78590,10 +78883,10 @@
     "dname": "+{s:bonus_slow}% Poof Slow"
   },
   "special_bonus_unique_meepo_2": {
-    "dname": "+{s:bonus_poof_damage} Poof Damage"
+    "dname": "+40 Poof Damage"
   },
   "special_bonus_unique_meepo_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Earthbind Cooldown"
+    "dname": "-1.5s Earthbind Cooldown"
   },
   "special_bonus_unique_meepo_4": {
     "dname": "Earthbind grants True Strike on Targets"
@@ -78602,7 +78895,7 @@
     "dname": "+{s:value} Divided We Stand Clone"
   },
   "special_bonus_unique_meepo_6": {
-    "dname": "+{s:bonus_health_steal_heroes} Ransack Health Steal"
+    "dname": "+6 Ransack Health Steal"
   },
   "special_bonus_unique_meepo_7": {
     "dname": "Pack Rat"
@@ -78611,13 +78904,13 @@
     "dname": "+{s:bonus_slow_duration}s Poof Slow Duration"
   },
   "special_bonus_unique_meepo_poof_cast_point": {
-    "dname": "-{s:bonus_cast_duration}s Poof Cast Duration"
+    "dname": "-.75s Poof Cast Duration"
   },
   "special_bonus_unique_monkey_king": {
     "dname": "+{s:value}% Boundless Strike Crit"
   },
   "special_bonus_unique_monkey_king_2": {
-    "dname": "+{s:bonus_bonus_damage} Jingu Mastery Damage"
+    "dname": "+110 Jingu Mastery Damage"
   },
   "special_bonus_unique_monkey_king_3": {
     "dname": "Jingu Mastery Undispellable"
@@ -78632,46 +78925,46 @@
     "dname": "Additional Wukong's Command Ring"
   },
   "special_bonus_unique_monkey_king_7": {
-    "dname": "+{s:bonus_ground_jump_distance} Tree Dance Cast Range"
+    "dname": "+300 Tree Dance Cast Range"
   },
   "special_bonus_unique_monkey_king_8": {
     "dname": "0 Cooldown Primal Spring"
   },
   "special_bonus_unique_monkey_king_9": {
-    "dname": "+{s:bonus_stun_duration}s Boundless Strike Stun Duration"
+    "dname": "+0.2s Boundless Strike Stun Duration"
   },
   "special_bonus_unique_monkey_king_10": {
-    "dname": "+{s:bonus_strike_crit_mult}% Boundless Strike Critical Damage"
+    "dname": "+60% Boundless Strike Critical Damage"
   },
   "special_bonus_unique_monkey_king_11": {
-    "dname": "-{s:bonus_required_hits} Jingu Mastery Required Hits"
+    "dname": "-1 Jingu Mastery Required Hits"
   },
   "special_bonus_unique_monkey_king_12": {
     "dname": "+{s:bonus_invul_duration}s Mischief Invulnerability Duration"
   },
   "special_bonus_unique_dark_willow_1": {
-    "dname": "+{s:bonus_duration}s Shadow Realm Duration"
+    "dname": "+1.5s Shadow Realm Duration"
   },
   "special_bonus_unique_dark_willow_2": {
-    "dname": "{s:bonus_impact_damage} Terrorize Impact Damage"
+    "dname": "500 Terrorize Impact Damage"
   },
   "special_bonus_unique_dark_willow_3": {
-    "dname": "-{s:bonus_AbilityCooldown}s Bramble Maze CD"
+    "dname": "-7s Bramble Maze CD"
   },
   "special_bonus_unique_dark_willow_4": {
-    "dname": "+{s:bonus_attack_damage} Bedlam Damage"
+    "dname": "+30 Bedlam Damage"
   },
   "special_bonus_unique_dark_willow_5": {
-    "dname": "-{s:bonus_AbilityCooldown}s Shadow Realm Cooldown"
+    "dname": "-2s Shadow Realm Cooldown"
   },
   "special_bonus_unique_dark_willow_6": {
-    "dname": "+{s:bonus_roaming_duration}s Bedlam Duration"
+    "dname": "+1.0s Bedlam Duration"
   },
   "special_bonus_unique_dark_willow_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Terrorize Cooldown"
+    "dname": "-20s Terrorize Cooldown"
   },
   "special_bonus_unique_dark_willow_bedlam_targets": {
-    "dname": "+{s:bonus_target_count} Bedlam Attack Targets"
+    "dname": "+2 Bedlam Attack Targets"
   },
   "special_bonus_unique_pangolier_2": {
     "dname": "{s:bonus_rolling_thunder_cooldown}s Shield Crash CD in Ball"
@@ -78680,30 +78973,30 @@
     "dname": "+{s:bonus_strikes} Swashbuckle Strike"
   },
   "special_bonus_unique_grimstroke_1": {
-    "dname": "+{s:bonus_radius} Ink Swell Radius"
+    "dname": "+150 Ink Swell Radius"
   },
   "special_bonus_unique_grimstroke_2": {
-    "dname": "+{s:bonus_damage}% Stroke of Fate Damage"
+    "dname": "+80% Stroke of Fate Damage"
   },
   "special_bonus_unique_grimstroke_3": {
-    "dname": "+{s:bonus_AbilityCastRange}% Stroke of Fate Speed and Travel Range"
+    "dname": "+70% Stroke of Fate Speed and Travel Range"
   },
   "special_bonus_unique_grimstroke_4": {
-    "dname": "+{s:bonus_destroy_attacks} Hits to Kill Phantom"
+    "dname": "+2 Attacks to Destroy Phantom"
   },
   "special_bonus_unique_grimstroke_5": {
     "dname": "+{s:value} Ink Swell Max Damage"
   },
   "special_bonus_unique_grimstroke_6": {
-    "dname": "+{s:bonus_movespeed_bonus_pct}% Ink Swell Movement Speed"
+    "dname": "+15% Ink Swell Movement Speed"
   },
   "special_bonus_unique_grimstroke_7": {
-    "dname": "-{s:bonus_AbilityCooldown}s Ink Swell Cooldown"
+    "dname": "-4s Ink Swell Cooldown"
   },
   "special_bonus_unique_grimstroke_8": {
-    "dname": "+{s:bonus_damage_per_second} Phantom's Embrace DPS"
+    "dname": "+65 Phantom's Embrace DPS"
   },
   "special_bonus_unique_grimstroke_soul_chain_reflect_damage": {
-    "dname": "+{s:bonus_bonus_reflected_spell_damage}% Soulbind Spell Damage"
+    "dname": "+25.0% Soulbind Spell Damage"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "patch": "node tasks/newpatch.ts",
     "prettier": "npx prettier --write tasks",
-    "build": "node tasks/updateconstants.ts"
+    "build": "node tasks/updateconstants.ts",
+    "test": "node --test"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/tasks/updateconstants.ts
+++ b/tasks/updateconstants.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import vdfparser from "vdf-parser";
-import { cleanupArray } from "./util.ts";
+import {
+  cleanupArray,
+  resolveSpecialBonusPlaceholders,
+  type SpecialBonusLookup,
+} from "./util.ts";
 
 const extraStrings = {
   DOTA_ABILITY_BEHAVIOR_NONE: "None",
@@ -655,6 +659,7 @@ async function start() {
             }
           }
         });
+        resolveSpecialBonusPlaceholders(abilities, specialBonusLookup);
         return abilities;
       },
     },
@@ -1654,7 +1659,7 @@ function removeSigns(template: string) {
     .replace("=", "");
 }
 
-let specialBonusLookup = {};
+let specialBonusLookup: SpecialBonusLookup = {};
 
 function replaceSValues(template: string, attribs: any[], key: string) {
   let values = specialBonusLookup[key] ?? {};

--- a/tasks/util.ts
+++ b/tasks/util.ts
@@ -23,3 +23,22 @@ export const cleanupArray = (array: string[]) => {
 
   return array.filter((n) => removeExtraneousWhitespacesFromString(n));
 };
+
+export type SpecialBonusLookup = Record<string, Record<string, string>>;
+
+export const resolveSpecialBonusPlaceholders = (
+  abilities: Record<string, { dname?: string }>,
+  lookup: SpecialBonusLookup,
+) => {
+  Object.entries(abilities).forEach(([name, ability]) => {
+    const values = lookup[name];
+    if (!ability.dname || !values) {
+      return;
+    }
+
+    ability.dname = ability.dname.replace(
+      /\{s:([^}]+)\}/g,
+      (placeholder, key) => values[key] ?? placeholder,
+    );
+  });
+};

--- a/test/updateconstants.test.ts
+++ b/test/updateconstants.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveSpecialBonusPlaceholders } from "../tasks/util.ts";
+
+test("resolves a talent placeholder after its linked ability is processed", () => {
+  const abilities = {
+    special_bonus_unique_axe_culling_blade_speed_duration: {
+      dname: "+{s:bonus_speed_duration}s Culling Blade Kill Buff Bonus Duration",
+    },
+  };
+  const lookup = {
+    special_bonus_unique_axe_culling_blade_speed_duration: {
+      bonus_speed_duration: "3",
+      value: "3",
+    },
+  };
+
+  resolveSpecialBonusPlaceholders(abilities, lookup);
+
+  assert.equal(
+    abilities.special_bonus_unique_axe_culling_blade_speed_duration.dname,
+    "+3s Culling Blade Kill Buff Bonus Duration",
+  );
+});
+
+test("keeps a placeholder when the current source data has no value for it", () => {
+  const abilities = {
+    special_bonus_unique_juggernaut_2: {
+      dname: "+{s:bonus_healing_ward_bonus_health} Healing Ward Hits to Kill",
+    },
+  };
+
+  resolveSpecialBonusPlaceholders(abilities, {});
+
+  assert.equal(
+    abilities.special_bonus_unique_juggernaut_2.dname,
+    "+{s:bonus_healing_ward_bonus_health} Healing Ward Hits to Kill",
+  );
+});


### PR DESCRIPTION
## Summary
- resolve known special-bonus placeholders after every ability has been processed
- add regression coverage for resolving a linked Axe talent and preserving a placeholder with no current source value
- regenerate `build/abilities.json`

Using the same current source data, this reduces unresolved `{s:...}` placeholders from 1,040 to 320. The remaining placeholders do not have a value in the current source data (for example, some legacy values are commented out upstream).

Addresses #172.

## Verification
- `npm test`