### PR TITLE
Add missing Largo talents

### DIFF
--- a/build/abilities.json
+++ b/build/abilities.json
@@ -75885,6 +75885,30 @@
   "special_bonus_unique_kez_switch_weapons_swap_bonus": {
     "dname": "+6% Switch Discipline Swap Bonuses"
   },
+  "special_bonus_unique_largo_1": {
+    "dname": "+15 Frogstomp Damage"
+  },
+  "special_bonus_unique_largo_2": {
+    "dname": "2.5x Catchy Lick Health Regen"
+  },
+  "special_bonus_unique_largo_3": {
+    "dname": "1% Croak of Genius Max Health DPS"
+  },
+  "special_bonus_unique_largo_4": {
+    "dname": "+100 Catchy Lick Cast Range / +50 Pull Distance"
+  },
+  "special_bonus_unique_largo_5": {
+    "dname": "2x Frogstomp Stomps/Interval"
+  },
+  "special_bonus_unique_largo_6": {
+    "dname": "50% Groovin' Armor Aura"
+  },
+  "special_bonus_unique_largo_7": {
+    "dname": "+30% Amphibian Rhapsody Song Effects"
+  },
+  "special_bonus_unique_largo_8": {
+    "dname": "2 Catchy Lick Charges"
+  },
   "special_bonus_unique_clockwerk": {
     "dname": "-0.25s Battery Assault Interval"
   },

--- a/tasks/updateconstants.ts
+++ b/tasks/updateconstants.ts
@@ -643,6 +643,21 @@ async function start() {
               aghsAbilityValues[key] = aghsObj;
             }
           });
+        // Some current talents are referenced by npc_heroes.txt but don't have
+        // their own DOTAAbilities block in the corresponding hero file. Add
+        // localized entries for those talents without pulling in unreferenced
+        // legacy talent strings.
+        getReferencedHeroTalents(heroesVdf.DOTAHeroes).forEach((talent) => {
+          if (abilities[talent]) {
+            return;
+          }
+          const dname =
+            strings[`DOTA_Tooltip_ability_${talent}`] ??
+            strings[`DOTA_Tooltip_Ability_${talent}`];
+          if (dname) {
+            abilities[talent] = { dname };
+          }
+        });
         // Some unique talents don't show up in each hero data file
         // e.g. special_bonus_unique_axe_8
         // Do a pass through the strings and if any are missing, add them with just basic description
@@ -1659,6 +1674,25 @@ function removeSigns(template: string) {
     .replace("=", "");
 }
 
+function getReferencedHeroTalents(heroes: Record<string, any>) {
+  const talents = new Set<string>();
+  Object.values(heroes).forEach((hero) => {
+    const talentStart = Number(hero.AbilityTalentStart ?? 10);
+    Object.entries(hero).forEach(([key, value]) => {
+      const match = key.match(/^Ability(\d+)$/);
+      if (
+        match &&
+        Number(match[1]) >= talentStart &&
+        typeof value === "string" &&
+        value.startsWith("special_bonus")
+      ) {
+        talents.add(value);
+      }
+    });
+  });
+  return talents;
+}
+
 let specialBonusLookup: SpecialBonusLookup = {};
 
 function replaceSValues(template: string, attribs: any[], key: string) {
@@ -1698,11 +1732,7 @@ function replaceSValues(template: string, attribs: any[], key: string) {
             }
 
             // Clean up the value by removing signs
-            specialBonusVal = specialBonusVal
-              .replace("+", "")
-              .replace("-", "")
-              .replace("x", "")
-              .replace("%", "");
+            specialBonusVal = removeSigns(specialBonusVal).replace("%", "");
 
             if (specialBonusKey in specialBonusLookup) {
               specialBonusLookup[specialBonusKey][bonusKey] = specialBonusVal;


### PR DESCRIPTION
## Summary

- synthesize localized entries for talents referenced by current hero data when their ability blocks are missing
- support both localization key casings without importing unreferenced legacy talents
- normalize `=` prefixes in linked talent values
- add the eight generated Largo talent entries

## Testing

- generated `abilities.json` from the pinned VPK data
- verified exactly eight new keys with resolved values
- `node --check tasks/updateconstants.ts`
- `npm test`
- `git diff --check`

Closes #176
